### PR TITLE
Track and filter namespaces on read and write respectively

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,38 +66,32 @@ harness = false
 name = "write"
 path = "examples/write.rs"
 required-features = ["io-write"]
-default-features = false
 
 [[example]]
 name = "unpack"
 path = "examples/unpack.rs"
 required-features = ["io-lazy-read"]
-default-features = false
 
 [[example]]
 name = "io_memory_optimized_read"
 path = "examples/io_memory_optimized_read.rs"
 required-features = ["io-memory-optimized-read"]
-default-features = false
 
 
 [[example]]
 name = "io_speed_optimized_read"
 path = "examples/io_speed_optimized_read.rs"
 required-features = ["io-speed-optimized-read"]
-default-features = false
 
 [[example]]
 name = "beamlattice_write"
 path = "examples/beamlattice_write.rs"
 required-features = ["io-write"]
-default-features = false
 
 [[example]]
 name = "string_extraction"
 path = "examples/string_extraction.rs"
 required-features = ["io-lazy-read"]
-default-features = false
 
 [package.metadata.cargo-all-features]
 max_combination_size = 3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # amrust_3mf
 
-A high-performance Rust library for reading and writing 3MF (3D Manufacturing Format) packages with both eager and lazy loading support.
+Library for reading and writing 3MF (3D Manufacturing Format) packages with both eager and lazy loading support.
 
 This crate provides a compact core model representation and I/O helpers for reading/writing 3MF packages with multiple loading strategies optimized for different use cases.
 
@@ -11,6 +11,8 @@ This crate provides a compact core model representation and I/O helpers for read
 | 3MF Core Spec      | Core      |    No    |                     1.3.0 |
 | Production         | Extension |    No    |                     1.1.2 |
 | Beam Lattice       | Extension |    No    |                     1.2.0 |
+
+**Note: This library is still in active development, expect frequent API changes!!**
 
 ## Overview
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -4,6 +4,24 @@ pub mod relationship;
 
 mod utils;
 pub use utils::parse_xmlns_attributes;
+
+/// Represents an XML namespace declaration with its prefix and URI
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XmlNamespace {
+    /// The namespace prefix (None for default namespace)
+    pub prefix: Option<String>,
+    /// The namespace URI
+    pub uri: String,
+}
+
+/// Stores namespace information for a specific model file
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelNamespaces {
+    /// Path to the model file
+    pub path: String,
+    /// List of namespaces declared in that model
+    pub namespaces: Vec<XmlNamespace>,
+}
 #[cfg(any(
     feature = "io-memory-optimized-read",
     feature = "io-speed-optimized-read"

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod relationship;
 
 mod utils;
+pub use utils::parse_xmlns_attributes;
 #[cfg(any(
     feature = "io-memory-optimized-read",
     feature = "io-speed-optimized-read"

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -6,7 +6,7 @@ mod utils;
 pub use utils::parse_xmlns_attributes;
 
 /// Represents an XML namespace declaration with its prefix and URI
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct XmlNamespace {
     /// The namespace prefix (None for default namespace)
     pub prefix: Option<String>,

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -6,7 +6,7 @@ mod utils;
 pub use utils::parse_xmlns_attributes;
 
 /// Represents an XML namespace declaration with its prefix and URI
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XmlNamespace {
     /// The namespace prefix (None for default namespace)
     pub prefix: Option<String>,

--- a/src/io/threemf_package_lazy_reader.rs
+++ b/src/io/threemf_package_lazy_reader.rs
@@ -363,8 +363,8 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
 
     fn load_model_from_archive(&self, path: &str) -> Result<Model, Error> {
         let mut archive = self.archive.borrow_mut();
-        let file = archive.by_name(utils::try_strip_leading_slash(path))?;
-        self.deserializer.deserialize_model(file)
+        let mut file = archive.by_name(utils::try_strip_leading_slash(path))?;
+        self.deserializer.deserialize_model(&mut file)
     }
 
     fn load_thumbnail_from_archive(&self, path: &str) -> Result<DynamicImage, Error> {

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -7,8 +7,7 @@ pub(crate) fn try_strip_leading_slash(target: &str) -> &str {
     }
 }
 
-/// Extracts xmlns attribute declarations from an XML tag
-/// Returns vec of XmlNamespace structs containing prefix and URI
+/// Extracts xmlns attribute declarations from an XML element attribute definitions
 pub fn parse_xmlns_attributes(tag_content: &str) -> Vec<XmlNamespace> {
     let mut attributes = Vec::new();
     let mut chars = tag_content.chars().peekable();
@@ -50,7 +49,7 @@ pub fn parse_xmlns_attributes(tag_content: &str) -> Vec<XmlNamespace> {
                 if chars.next() == Some('=') && chars.next() == Some('"') {
                     let mut uri = String::new();
                     // Read until closing quote
-                    while let Some(ch) = chars.next() {
+                    for ch in chars.by_ref() {
                         if ch == '"' {
                             break;
                         }
@@ -66,25 +65,43 @@ pub fn parse_xmlns_attributes(tag_content: &str) -> Vec<XmlNamespace> {
 }
 
 #[cfg(test)]
-mod tests {
+mod smoke_tests {
     use super::*;
 
     #[test]
     fn test_parse_xmlns_attributes_simple() {
         let xml = r#"<model xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02" unit="millimeter">"#;
         let attrs = parse_xmlns_attributes(xml);
-        assert_eq!(attrs, vec![XmlNamespace { prefix: None, uri: "http://schemas.microsoft.com/3dmanufacturing/core/2015/02".to_string() }]);
+        assert_eq!(
+            attrs,
+            vec![XmlNamespace {
+                prefix: None,
+                uri: "http://schemas.microsoft.com/3dmanufacturing/core/2015/02".to_string()
+            }]
+        );
     }
 
     #[test]
     fn test_parse_xmlns_attributes_prefixed() {
         let xml = r#"<model xmlns="http://core" xmlns:p="http://prod" xmlns:b="http://beam">"#;
         let attrs = parse_xmlns_attributes(xml);
-        assert_eq!(attrs, vec![
-            XmlNamespace { prefix: None, uri: "http://core".to_string() },
-            XmlNamespace { prefix: Some("p".to_string()), uri: "http://prod".to_string() },
-            XmlNamespace { prefix: Some("b".to_string()), uri: "http://beam".to_string() },
-        ]);
+        assert_eq!(
+            attrs,
+            vec![
+                XmlNamespace {
+                    prefix: None,
+                    uri: "http://core".to_string()
+                },
+                XmlNamespace {
+                    prefix: Some("p".to_string()),
+                    uri: "http://prod".to_string()
+                },
+                XmlNamespace {
+                    prefix: Some("b".to_string()),
+                    uri: "http://beam".to_string()
+                },
+            ]
+        );
     }
 
     #[test]
@@ -98,9 +115,18 @@ mod tests {
     fn test_parse_xmlns_attributes_mixed() {
         let xml = r#"<model xmlns="http://core" unit="millimeter" xmlns:p="http://prod" requiredextensions="ext">"#;
         let attrs = parse_xmlns_attributes(xml);
-        assert_eq!(attrs, vec![
-            XmlNamespace { prefix: None, uri: "http://core".to_string() },
-            XmlNamespace { prefix: Some("p".to_string()), uri: "http://prod".to_string() },
-        ]);
+        assert_eq!(
+            attrs,
+            vec![
+                XmlNamespace {
+                    prefix: None,
+                    uri: "http://core".to_string()
+                },
+                XmlNamespace {
+                    prefix: Some("p".to_string()),
+                    uri: "http://prod".to_string()
+                },
+            ]
+        );
     }
 }

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -4,3 +4,99 @@ pub(crate) fn try_strip_leading_slash(target: &str) -> &str {
         None => target,
     }
 }
+
+/// Extracts xmlns attribute declarations from an XML tag
+/// Returns vec of (attribute_name, uri) pairs
+/// e.g., [("xmlns", "http://..."), ("xmlns:p", "http://...")]
+pub fn parse_xmlns_attributes(tag_content: &str) -> Vec<(String, String)> {
+    let mut attributes = Vec::new();
+    let mut chars = tag_content.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == 'x' {
+            // Check for "xmlns" or "xmlns:"
+            let mut attr_name = String::from("x");
+            let mut is_xmlns = true;
+
+            // Read rest of potential "xmlns" or "xmlns:"
+            for expected in ['m', 'l', 'n', 's'] {
+                if chars.peek() == Some(&expected) {
+                    attr_name.push(chars.next().unwrap());
+                } else {
+                    is_xmlns = false;
+                    break;
+                }
+            }
+
+            if is_xmlns {
+                // Check for colon (namespaced)
+                if chars.peek() == Some(&':') {
+                    attr_name.push(chars.next().unwrap());
+                    // Read namespace prefix
+                    while let Some(&ch) = chars.peek() {
+                        if ch.is_alphabetic() || ch == '_' || ch == '-' {
+                            attr_name.push(chars.next().unwrap());
+                        } else {
+                            break;
+                        }
+                    }
+                }
+
+                // Expect equals sign
+                if chars.next() == Some('=') && chars.next() == Some('"') {
+                    let mut uri = String::new();
+                    // Read until closing quote
+                    while let Some(ch) = chars.next() {
+                        if ch == '"' {
+                            break;
+                        }
+                        uri.push(ch);
+                    }
+                    attributes.push((attr_name, uri));
+                }
+            }
+        }
+    }
+
+    attributes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_xmlns_attributes_simple() {
+        let xml = r#"<model xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02" unit="millimeter">"#;
+        let attrs = parse_xmlns_attributes(xml);
+        assert_eq!(attrs, vec![("xmlns".to_string(), "http://schemas.microsoft.com/3dmanufacturing/core/2015/02".to_string())]);
+    }
+
+    #[test]
+    fn test_parse_xmlns_attributes_prefixed() {
+        let xml = r#"<model xmlns="http://core" xmlns:p="http://prod" xmlns:b="http://beam">"#;
+        let attrs = parse_xmlns_attributes(xml);
+        assert_eq!(attrs, vec![
+            ("xmlns".to_string(), "http://core".to_string()),
+            ("xmlns:p".to_string(), "http://prod".to_string()),
+            ("xmlns:b".to_string(), "http://beam".to_string()),
+        ]);
+    }
+
+    #[test]
+    fn test_parse_xmlns_attributes_empty() {
+        let xml = r#"<model unit="millimeter">"#;
+        let attrs = parse_xmlns_attributes(xml);
+        assert_eq!(attrs, Vec::<(String, String)>::new());
+    }
+
+    #[test]
+    fn test_parse_xmlns_attributes_mixed() {
+        let xml = r#"<model xmlns="http://core" unit="millimeter" xmlns:p="http://prod" requiredextensions="ext">"#;
+        let attrs = parse_xmlns_attributes(xml);
+        assert_eq!(attrs, vec![
+            ("xmlns".to_string(), "http://core".to_string()),
+            ("xmlns:p".to_string(), "http://prod".to_string()),
+        ]);
+    }
+}

--- a/src/io/zip_utils.rs
+++ b/src/io/zip_utils.rs
@@ -68,7 +68,7 @@ impl XmlDeserializer {
         }
     }
 
-    pub(crate) fn deserialize_model<R: Read>(&self, mut reader: R) -> Result<Model, Error> {
+    pub(crate) fn deserialize_model<R: Read>(&self, reader: &mut R) -> Result<Model, Error> {
         match self {
             #[cfg(feature = "io-memory-optimized-read")]
             XmlDeserializer::MemoryOptimized => {

--- a/src/threemf_namespaces.rs
+++ b/src/threemf_namespaces.rs
@@ -21,3 +21,39 @@ pub const BEAM_LATTICE_PREFIX: &str = "b";
 pub const BEAM_LATTICE_BALLS_NS: &str =
     "http://schemas.microsoft.com/3dmanufacturing/beamlattice/balls/2020/07";
 pub const BEAM_LATTICE_BALLS_PREFIX: &str = "b2";
+
+/// Enum representing the different XML namespaces used in 3MF
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ThreemfNamespace {
+    Core,
+    Prod,
+    BeamLattice,
+    CoreTriangleSet,
+}
+
+impl ThreemfNamespace {
+    pub fn uri(&self) -> &'static str {
+        match self {
+            Self::Core => CORE_NS,
+            Self::Prod => PROD_NS,
+            Self::BeamLattice => BEAM_LATTICE_NS,
+            Self::CoreTriangleSet => CORE_TRIANGLESET_NS,
+        }
+    }
+
+    pub fn prefix(&self) -> Option<&'static str> {
+        match self {
+            Self::Core => None, // default namespace
+            Self::Prod => Some(PROD_PREFIX),
+            Self::BeamLattice => Some(BEAM_LATTICE_PREFIX),
+            Self::CoreTriangleSet => Some(CORE_TRIANGLESET_PREFIX),
+        }
+    }
+
+    pub fn xmlns_declaration(&self) -> String {
+        match self.prefix() {
+            Some(prefix) => format!(r#" xmlns:{}="{}""#, prefix, self.uri()),
+            None => format!(r#" xmlns="{}""#, self.uri()),
+        }
+    }
+}

--- a/tests/core_io.rs
+++ b/tests/core_io.rs
@@ -95,12 +95,10 @@ mod smoke_tests {
         }
     }
 
-    #[cfg(feature = "io-lazy-read")]
+    #[cfg(all(feature = "io-lazy-read", feature = "io-memory-optimized-read"))]
     #[test]
     fn read_threemf_package_lazy_memory_optimized() {
-        use std::collections::HashSet;
-
-        use amrust_3mf::io::{CachePolicy, ThreemfPackageLazyReader, XmlNamespace};
+        use amrust_3mf::io::{CachePolicy, ThreemfPackageLazyReader};
 
         let path = PathBuf::from("./tests/data/mesh-composedpart.3mf");
         let reader = File::open(path).unwrap();
@@ -112,68 +110,117 @@ mod smoke_tests {
 
         assert!(result.is_ok());
 
-        let mut namespaces: HashSet<XmlNamespace> = HashSet::new();
+        let mut namespaces = vec![];
 
         match result {
             Ok(package) => {
                 assert_eq!(package.relationships().len(), 1);
 
-                // Count total objects using with_model pattern
+                let mut total_model_paths = 0;
                 let mut total_objects = 0;
-                for model_path in package.model_paths() {
-                    package
-                        .with_model(model_path, |(model, ns)| {
-                            total_objects += model.resources.object.len();
-
-                            ns.iter().all(|ns| namespaces.insert(ns.clone()));
-                        })
-                        .unwrap();
-                }
-                assert_eq!(total_objects, 4);
-
-                // Count mesh objects using with_model pattern
                 let mut mesh_objects = 0;
-                for model_path in package.model_paths() {
-                    package
-                        .with_model(model_path, |(model, ns)| {
-                            mesh_objects += model
-                                .resources
-                                .object
-                                .iter()
-                                .filter(|o| o.mesh.is_some())
-                                .count();
-
-                            ns.iter().all(|ns| namespaces.insert(ns.clone()));
-                        })
-                        .unwrap();
-                }
-                assert_eq!(mesh_objects, 3);
-
-                // Count composedpart objects using with_model pattern
                 let mut composedpart_objects = 0;
+
+                // Check object by ID in specific model path
+                let mut found_object_by_id = false;
+
+                //iterate through all models and search for objects and the used namespaces
                 for model_path in package.model_paths() {
+                    total_model_paths += 1;
                     package
                         .with_model(model_path, |(model, ns)| {
-                            composedpart_objects += model
-                                .resources
-                                .object
-                                .iter()
-                                .filter(|o| o.components.is_some())
-                                .count();
+                            //check if some part with some specific id exists
+                            if model.resources.object.iter().any(|o| o.id == 1) {
+                                found_object_by_id = true;
+                            }
 
-                            ns.iter().all(|ns| namespaces.insert(ns.clone()));
+                            for obj in &model.resources.object {
+                                total_objects += 1;
+                                if obj.mesh.is_some() {
+                                    mesh_objects += 1;
+                                } else if obj.components.is_some() {
+                                    composedpart_objects += 1;
+                                }
+                            }
+
+                            namespaces.extend_from_slice(ns);
                         })
                         .unwrap();
                 }
+                assert_eq!(total_model_paths, 1);
+                assert_eq!(total_objects, 4);
+                assert_eq!(mesh_objects, 3);
                 assert_eq!(composedpart_objects, 1);
+                assert!(found_object_by_id);
 
-                let (root_model, root_ns) = package.root_model().unwrap();
-                let object_by_id = root_model.resources.object.iter().find(|o| o.id == 1);
-                assert!(object_by_id.is_some());
+                //contains core, prod and material
+                assert_eq!(namespaces.len(), 3);
+            }
+            Err(err) => {
+                panic!("read failed {:?}", err);
+            }
+        }
+    }
 
-                assert_eq!(2, root_model.build.item.len());
+    #[cfg(all(feature = "io-lazy-read", feature = "io-speed-optimized-read"))]
+    #[test]
+    fn read_threemf_package_lazy_speed_optimized() {
+        use amrust_3mf::io::{CachePolicy, ThreemfPackageLazyReader};
 
-                root_ns.iter().all(|ns| namespaces.insert(ns.clone()));
+        let path = PathBuf::from("./tests/data/mesh-composedpart.3mf");
+        let reader = File::open(path).unwrap();
+
+        let result = ThreemfPackageLazyReader::from_reader_with_speed_optimized_deserializer(
+            reader,
+            CachePolicy::NoCache,
+        );
+
+        assert!(result.is_ok());
+
+        let mut namespaces = vec![];
+
+        match result {
+            Ok(package) => {
+                assert_eq!(package.relationships().len(), 1);
+
+                let mut total_model_paths = 0;
+                let mut total_objects = 0;
+                let mut mesh_objects = 0;
+                let mut composedpart_objects = 0;
+
+                // Check object by ID in specific model path
+                let mut found_object_by_id = false;
+
+                //iterate through all models and search for objects and the used namespaces
+                for model_path in package.model_paths() {
+                    total_model_paths += 1;
+                    package
+                        .with_model(model_path, |(model, ns)| {
+                            //check if some part with some specific id exists
+                            if model.resources.object.iter().any(|o| o.id == 1) {
+                                found_object_by_id = true;
+                            }
+
+                            for obj in &model.resources.object {
+                                total_objects += 1;
+                                if obj.mesh.is_some() {
+                                    mesh_objects += 1;
+                                } else if obj.components.is_some() {
+                                    composedpart_objects += 1;
+                                }
+                            }
+
+                            namespaces.extend_from_slice(ns);
+                        })
+                        .unwrap();
+                }
+                assert_eq!(total_model_paths, 1);
+                assert_eq!(total_objects, 4);
+                assert_eq!(mesh_objects, 3);
+                assert_eq!(composedpart_objects, 1);
+                assert!(found_object_by_id);
+
+                //contains core, prod and material
                 assert_eq!(namespaces.len(), 3);
             }
             Err(err) => {

--- a/tests/production_io.rs
+++ b/tests/production_io.rs
@@ -129,33 +129,28 @@ mod smoke_tests {
         }
     }
 
-    #[cfg(feature = "io-lazy-read")]
+    #[cfg(all(feature = "io-lazy-read", feature = "io-memory-optimized-read"))]
     #[test]
     fn read_threemf_package_lazy_memory_optimized() {
-        use std::collections::HashSet;
-
-        use amrust_3mf::io::{CachePolicy, ThreemfPackageLazyReader, XmlNamespace};
+        use amrust_3mf::io::{CachePolicy, ThreemfPackageLazyReader};
 
         let path = PathBuf::from("./tests/data/mesh-composedpart-separate-model-files.3mf");
         let reader = File::open(path).unwrap();
 
-        let result = ThreemfPackageLazyReader::from_reader_with_speed_optimized_deserializer(
+        let result = ThreemfPackageLazyReader::from_reader_with_memory_optimized_deserializer(
             reader,
             CachePolicy::NoCache,
         );
 
         assert!(result.is_ok());
 
-        let mut namespaces: HashSet<XmlNamespace> = HashSet::new();
+        let mut namespaces = vec![];
 
         match result {
             Ok(package) => {
-                assert_eq!(package.relationships().len(), 5);
+                assert_eq!(package.relationships().len(), 4);
 
-                let model_paths = package.model_paths().collect::<Vec<_>>();
-                println!("{model_paths:?}");
-                assert_eq!(model_paths.len(), 5);
-
+                let mut total_model_paths = 0;
                 let mut total_objects = 0;
                 let mut mesh_objects = 0;
                 let mut composedpart_objects = 0;
@@ -168,8 +163,10 @@ mod smoke_tests {
 
                 //iterate through all models and search for objects and the used namespaces
                 for model_path in package.model_paths() {
+                    total_model_paths += 1;
                     package
                         .with_model(model_path, |(model, ns)| {
+                            //check if some part with some id exists in a specific sub-model
                             if model_path == "/3D/Objects/Object.model"
                                 && model.resources.object.iter().any(|o| o.id == 1)
                             {
@@ -190,12 +187,11 @@ mod smoke_tests {
                                 }
                             }
 
-                            ns.iter().all(|ns| namespaces.insert(ns.clone()));
-                            println!("Model Path: {model_path} && Namespaces: {ns:?}");
-                            println!("");
+                            namespaces.extend_from_slice(ns);
                         })
                         .unwrap();
                 }
+                assert_eq!(total_model_paths, 3);
                 assert_eq!(total_objects, 4);
                 assert_eq!(mesh_objects, 3);
                 assert_eq!(composedpart_objects, 1);
@@ -203,7 +199,7 @@ mod smoke_tests {
                 assert!(found_object_by_id);
 
                 // Check build item UUID in root model
-                let (root_model, root_ns) = package.root_model().unwrap();
+                let (root_model, _) = package.root_model().unwrap();
                 let can_find_build_item_by_uuid = root_model.build.item.iter().find(|i| {
                     if let Some(uuid) = &i.uuid {
                         uuid == "637f47fa-39e6-4363-b3a9-100329fc5d9c"
@@ -213,9 +209,97 @@ mod smoke_tests {
                 });
                 assert!(can_find_build_item_by_uuid.is_some());
 
-                //root_ns.iter().all(|ns| namespaces.insert(ns.clone()));
-                println!("Namespaces: {namespaces:?}");
-                assert_eq!(namespaces.len(), 3);
+                //8 namespaces = (3 in each sub models + 2 in root model)
+                assert_eq!(namespaces.len(), 8);
+            }
+            Err(err) => {
+                panic!("read failed {:?}", err);
+            }
+        }
+    }
+
+    #[cfg(all(feature = "io-lazy-read", feature = "io-speed-optimized-read"))]
+    #[test]
+    fn read_threemf_package_lazy_speed_optimized() {
+        use amrust_3mf::io::{CachePolicy, ThreemfPackageLazyReader};
+
+        let path = PathBuf::from("./tests/data/mesh-composedpart-separate-model-files.3mf");
+        let reader = File::open(path).unwrap();
+
+        let result = ThreemfPackageLazyReader::from_reader_with_speed_optimized_deserializer(
+            reader,
+            CachePolicy::NoCache,
+        );
+
+        assert!(result.is_ok());
+
+        let mut namespaces = vec![];
+
+        match result {
+            Ok(package) => {
+                assert_eq!(package.relationships().len(), 4);
+
+                let mut total_model_paths = 0;
+                let mut total_objects = 0;
+                let mut mesh_objects = 0;
+                let mut composedpart_objects = 0;
+
+                // can find a specific mesh object with a specific uuid
+                let mut found_object_by_uuid = false;
+
+                // Check object by ID in specific model path
+                let mut found_object_by_id = false;
+
+                //iterate through all models and search for objects and the used namespaces
+                for model_path in package.model_paths() {
+                    total_model_paths += 1;
+                    package
+                        .with_model(model_path, |(model, ns)| {
+                            //check if some part with some id exists in a specific sub-model
+                            if model_path == "/3D/Objects/Object.model"
+                                && model.resources.object.iter().any(|o| o.id == 1)
+                            {
+                                found_object_by_id = true;
+                            }
+
+                            for obj in &model.resources.object {
+                                total_objects += 1;
+                                if obj.mesh.is_some() {
+                                    mesh_objects += 1;
+                                    if let Some(uuid) = &obj.uuid
+                                        && uuid == "79f98073-4eaa-4737-b065-041b98fb50a6"
+                                    {
+                                        found_object_by_uuid = true;
+                                    }
+                                } else if obj.components.is_some() {
+                                    composedpart_objects += 1;
+                                }
+                            }
+
+                            namespaces.extend_from_slice(ns);
+                        })
+                        .unwrap();
+                }
+                assert_eq!(total_model_paths, 3);
+                assert_eq!(total_objects, 4);
+                assert_eq!(mesh_objects, 3);
+                assert_eq!(composedpart_objects, 1);
+                assert!(found_object_by_uuid);
+                assert!(found_object_by_id);
+
+                // Check build item UUID in root model
+                let (root_model, _) = package.root_model().unwrap();
+                let can_find_build_item_by_uuid = root_model.build.item.iter().find(|i| {
+                    if let Some(uuid) = &i.uuid {
+                        uuid == "637f47fa-39e6-4363-b3a9-100329fc5d9c"
+                    } else {
+                        false
+                    }
+                });
+                assert!(can_find_build_item_by_uuid.is_some());
+
+                //8 namespaces = (3 in each sub models + 2 in root model)
+                assert_eq!(namespaces.len(), 8);
             }
             Err(err) => {
                 panic!("read failed {:?}", err);

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -67,9 +67,8 @@ mod smoke_tests {
             beamlattice: None,
         };
 
-        let write_package = ThreemfPackage {
-            root: Model {
-                // xmlns: None,
+        let write_package = ThreemfPackage::new(
+            Model {
                 unit: Some(Unit::Millimeter),
                 requiredextensions: None,
                 recommendedextensions: None,
@@ -100,10 +99,10 @@ mod smoke_tests {
                     }],
                 },
             },
-            sub_models: HashMap::new(),
-            thumbnails: HashMap::new(),
-            unknown_parts: HashMap::new(),
-            relationships: HashMap::from([(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([(
                 "_rels/.rels".to_owned(),
                 Relationships {
                     relationships: vec![Relationship {
@@ -113,7 +112,7 @@ mod smoke_tests {
                     }],
                 },
             )]),
-            content_types: ContentTypes {
+            ContentTypes {
                 defaults: vec![
                     DefaultContentTypes {
                         extension: "rels".to_owned(),
@@ -125,7 +124,7 @@ mod smoke_tests {
                     },
                 ],
             },
-        };
+        );
 
         let mut buf = Cursor::new(Vec::new());
 

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -133,17 +133,23 @@ mod smoke_tests {
             .expect("Error writing package");
         #[cfg(feature = "io-memory-optimized-read")]
         {
-            let models =
+            let package =
                 ThreemfPackage::from_reader_with_memory_optimized_deserializer(&mut buf, false)
                     .expect("Error reading package");
-            assert_eq!(models, write_package);
+            assert_eq!(package, write_package);
+
+            let ns = package.get_namespaces_on_model(None).unwrap();
+            assert_eq!(ns.len(), 1);
         }
         #[cfg(feature = "io-speed-optimized-read")]
         {
-            let models =
+            let package =
                 ThreemfPackage::from_reader_with_speed_optimized_deserializer(&mut buf, false)
                     .expect("Error reading package");
-            assert_eq!(models, write_package);
+            assert_eq!(package, write_package);
+
+            let ns = package.get_namespaces_on_model(None).unwrap();
+            assert_eq!(ns.len(), 1);
         }
 
         // Test lazy reader roundtrip
@@ -164,7 +170,7 @@ mod smoke_tests {
             assert!(lazy_package.root_model_path().contains("3Dmodel.model"));
 
             // Verify root model content
-            let root_model = lazy_package.root_model().unwrap();
+            let (root_model, root_ns) = lazy_package.root_model().unwrap();
             assert_eq!(root_model.resources.object.len(), 1);
             assert_eq!(root_model.build.item.len(), 1);
 

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -152,7 +152,6 @@ mod smoke_tests {
             assert_eq!(ns.len(), 1);
         }
 
-        // Test lazy reader roundtrip
         #[cfg(feature = "io-lazy-read")]
         {
             use amrust_3mf::io::{CachePolicy, ThreemfPackageLazyReader};
@@ -170,9 +169,10 @@ mod smoke_tests {
             assert!(lazy_package.root_model_path().contains("3Dmodel.model"));
 
             // Verify root model content
-            let (root_model, root_ns) = lazy_package.root_model().unwrap();
+            let (root_model, ns) = lazy_package.root_model().unwrap();
             assert_eq!(root_model.resources.object.len(), 1);
             assert_eq!(root_model.build.item.len(), 1);
+            assert_eq!(ns.len(), 1);
 
             let obj = &root_model.resources.object[0];
             assert_eq!(obj.id, 1);


### PR DESCRIPTION
- Added additional helper methods to check for used namespaces on the Model directly for write feature
- On write, unused namespaces are no longer included in the XML for 3MF Model by default
- New XmlNamespace structure introduced to track the namespace and prefix specified in an XML file
- On read through ThreemfPackage, an additional function get_namespaces_on_model is added to return list of XMLNamespace specified on a specific 3MF Model document
- On read through ThreemfPackageLazyReader, with_model function takes in a closure of fn((&Model, Vec<XMLNamespace>)) for access to XMLNamespace list
- Updated tests to include Namespace checks

- Undo unnecessary changes caused by AI assisted coding from previous commit. 