### PR TITLE
feat(core, io): Introduce ThreemfExtensions type to manage extension namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 *.json.gz
+*prof.json
+*.etl
 nul

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,18 +85,21 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -402,7 +405,7 @@ dependencies = [
  "dashmap",
  "indexmap",
  "parking_lot",
- "quick-xml",
+ "quick-xml 0.37.5",
  "regex",
  "smallvec",
  "tempfile",
@@ -660,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "instant-xml"
-version = "0.6.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bcb52e60a2cf65351b560d7536d313a074618105c749e98a2003eddf5d87901"
+checksum = "f5aab9a4682ad90fdb1dae4f2edbf1533f4a43d4dea366eb7447aca52489e9b4"
 dependencies = [
  "instant-xml-macros",
  "thiserror",
@@ -671,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "instant-xml-macros"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3d67ed155f9fcaa11e0d34743ecb0216f96d48e67a467f09b010d3d235a07c"
+checksum = "44127a3a387c070ef0656a6ce53dd0e616cf8d6cf5b159aa478cfd49e1c166e0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -776,6 +779,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "lib3mf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909b625efea54d0a560d2a1b2483cedb313f90200f7fc5e39e7e3a191b87fe6a"
+dependencies = [
+ "quick-xml 0.39.4",
+ "thiserror",
+ "urlencoding",
+ "zip 8.4.0",
+]
+
+[[package]]
 name = "lib3mf-core"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,7 +800,7 @@ dependencies = [
  "byteorder",
  "glam 0.31.1",
  "lexical-core",
- "quick-xml",
+ "quick-xml 0.37.5",
  "rayon",
  "serde",
  "serde_json",
@@ -1048,6 +1063,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "serde-roxmltree"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc12f21d1a0140947366bf6903ba739f0f6fa95d32dd7afd0982e934ef2df2aa"
+checksum = "9802bf0221cb405aaf5b00aea5fe3655dc71595a9ba5709840332a16d54b27df"
 dependencies = [
  "bit-set",
  "roxmltree",
@@ -1344,6 +1368,7 @@ dependencies = [
  "serde-roxmltree",
  "serde_json",
  "thiserror",
+ "xmlparser",
  "zip 8.4.0",
 ]
 
@@ -1354,6 +1379,7 @@ dependencies = [
  "criterion",
  "dhat",
  "instant-xml",
+ "lib3mf",
  "lib3mf-core",
  "serde",
  "serde-roxmltree",
@@ -1476,6 +1502,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,7 +1368,6 @@ dependencies = [
  "serde-roxmltree",
  "serde_json",
  "thiserror",
- "xmlparser",
  "zip 8.4.0",
 ]
 

--- a/threemf2-benches/Cargo.toml
+++ b/threemf2-benches/Cargo.toml
@@ -6,14 +6,16 @@ edition = "2024"
 license = "MIT or Apache-2.0"
 
 [dependencies]
-instant-xml = { version = "0.6.0" }
-serde-roxmltree = { version = "0.10.0" }
+instant-xml = { version = "0.7.4" }
+# instant-xml = { version = "0.7.4", path = "../../../../instant-xml/instant-xml/instant-xml", optional = true }
+serde-roxmltree = { version = "0.11.1" }
 threemf2 = { path = "../threemf2", features = [
     "io-memory-optimized-read",
     "io-speed-optimized-read",
     "io-write",
 ] }
 lib3mf-core = { version = "0.4.0", features = ["parallel"] }
+lib3mf = { version = "0.1.6", default-features = false }
 zip = { version = "8.4.0", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]

--- a/threemf2-benches/benches/threemf_reader_multi.rs
+++ b/threemf2-benches/benches/threemf_reader_multi.rs
@@ -112,10 +112,37 @@ fn bench_lib3mf_rs(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_lib3mf(c: &mut Criterion) {
+    let config: Config = serde_json::from_str(CONFIG_JSON).unwrap();
+    let mut group = c.benchmark_group("lib3mf");
+    group.sample_size(10);
+    group.measurement_time(std::time::Duration::from_secs(30));
+
+    for file in &config.files {
+        let path = PathBuf::from(format!("../threemf2-tests/tests/data/{}", file.path))
+            .canonicalize()
+            .unwrap();
+        let name = get_short_name(&file.path);
+
+        #[cfg(feature = "enable-alloc-check")]
+        let _dhat = dhat::Profiler::builder()
+            .file_name(format!("/target/dhat-speed-optimized-{name}.json"))
+            .build();
+        group.bench_with_input(BenchmarkId::new("read", name), &path, |b, path| {
+            b.iter(|| {
+                let file = std::fs::File::open(path).unwrap();
+                if lib3mf::Model::from_reader(file).is_ok() {}
+            });
+        });
+    }
+    group.finish();
+}
+
 #[cfg(feature = "benchmark-all")]
 criterion_group!(
     benches,
     bench_memory_optimized,
+    bench_lib3mf,
     bench_speed_optimized,
     bench_lib3mf_rs
 );

--- a/threemf2-benches/benches/threemf_reader_multi.rs
+++ b/threemf2-benches/benches/threemf_reader_multi.rs
@@ -95,7 +95,7 @@ fn bench_lib3mf_rs(c: &mut Criterion) {
 
         #[cfg(feature = "enable-alloc-check")]
         let _dhat = dhat::Profiler::builder()
-            .file_name(format!("/target/dhat-speed-optimized-{name}.json"))
+            .file_name(format!("/target/dhat-lib3mf_rs-{name}.json"))
             .build();
         group.bench_with_input(BenchmarkId::new("read", name), &path, |b, path| {
             b.iter(|| {
@@ -126,7 +126,7 @@ fn bench_lib3mf(c: &mut Criterion) {
 
         #[cfg(feature = "enable-alloc-check")]
         let _dhat = dhat::Profiler::builder()
-            .file_name(format!("/target/dhat-speed-optimized-{name}.json"))
+            .file_name(format!("/target/dhat-lib3mf-{name}.json"))
             .build();
         group.bench_with_input(BenchmarkId::new("read", name), &path, |b, path| {
             b.iter(|| {

--- a/threemf2-tests/Cargo.toml
+++ b/threemf2-tests/Cargo.toml
@@ -17,5 +17,6 @@ threemf2 = { path = "../threemf2", features = [
 pretty_assertions = { version = "1.4.1" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.140" }
-serde-roxmltree = { version = "0.10.0" }
-instant-xml = { version = "0.6.0" }
+serde-roxmltree = { version = "0.11.1" }
+instant-xml = { version = "0.7.4" }
+# instant-xml = { version = "0.7.4", path = "../../../../instant-xml/instant-xml/instant-xml" }

--- a/threemf2-thumbnail/examples/thumbnail_generation.rs
+++ b/threemf2-thumbnail/examples/thumbnail_generation.rs
@@ -5,7 +5,10 @@
 //!
 //! Run with: cargo run --example thumbnail_generation --features thumbnail-generation
 
-use threemf2::core::{model::Model, object::ObjectKind};
+use threemf2::core::{
+    model::{Model, ThreemfExtensions},
+    object::ObjectKind,
+};
 use threemf2_thumbnail::{ThumbnailConfig, ThumbnailGenerator};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -229,7 +232,7 @@ fn create_cube_model() -> Model {
         metadata: vec![],
         resources,
         build,
-        recommendedextensions: None,
-        requiredextensions: None,
+        recommendedextensions: ThreemfExtensions::default(),
+        requiredextensions: ThreemfExtensions::default(),
     }
 }

--- a/threemf2-thumbnail/src/thumbnail_generator.rs
+++ b/threemf2-thumbnail/src/thumbnail_generator.rs
@@ -429,6 +429,7 @@ impl Default for ThumbnailGenerator {
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
+    use threemf2::core::model::ThreemfExtensions;
 
     use super::*;
     use threemf2::core::build::Build;
@@ -731,8 +732,8 @@ mod tests {
                 uuid: None,
                 item: vec![],
             },
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
         };
 
         let generator = ThumbnailGenerator::default();

--- a/threemf2-xsd-validation/tests/beamlattice_validation.rs
+++ b/threemf2-xsd-validation/tests/beamlattice_validation.rs
@@ -11,7 +11,7 @@ use threemf2::{
         beamlattice::{Ball, BallMode, Balls, Beam, BeamLattice, Beams, CapMode},
         build::{Build, Item},
         mesh::{Mesh, Triangle, Triangles, Vertex, Vertices},
-        model::{Model, Unit},
+        model::{Model, ThreemfExtensions, Unit},
         object::{Object, ObjectKind, ObjectType},
         resources::Resources,
         types::OptionalResourceIndex,
@@ -21,6 +21,7 @@ use threemf2::{
         content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
         relationship::{Relationship, RelationshipType, Relationships},
     },
+    threemf_namespaces::ThreemfNamespace,
 };
 
 mod validation_utils;
@@ -162,8 +163,8 @@ fn validate_simple_beamlattice() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: Some("b".to_owned()),
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::BeamLattice]),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![Object {
@@ -332,8 +333,11 @@ fn validate_beamlattice_with_balls() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: Some("b b2".to_owned()),
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::new(&[
+                ThreemfNamespace::BeamLattice,
+                ThreemfNamespace::BeamLatticeBalls,
+            ]),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![Object {

--- a/threemf2-xsd-validation/tests/booleanoperations_validation.rs
+++ b/threemf2-xsd-validation/tests/booleanoperations_validation.rs
@@ -11,7 +11,7 @@ use threemf2::{
         boolean::{Boolean, BooleanOperation, BooleanShape},
         build::{Build, Item},
         mesh::{Mesh, Triangle, Triangles, Vertex, Vertices},
-        model::{Model, Unit},
+        model::{Model, ThreemfExtensions, Unit},
         object::{Object, ObjectKind, ObjectType},
         resources::Resources,
         transform::Transform,
@@ -22,6 +22,7 @@ use threemf2::{
         content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
         relationship::{Relationship, RelationshipType, Relationships},
     },
+    threemf_namespaces::ThreemfNamespace,
 };
 
 mod validation_utils;
@@ -448,8 +449,8 @@ fn validate_simple_boolean_difference() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: Some("bo".to_owned()),
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![
@@ -579,8 +580,8 @@ fn validate_simple_boolean_intersection() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: Some("bo".to_owned()),
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![
@@ -726,8 +727,8 @@ fn validate_boolean_with_multiple_operands() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: Some("bo".to_owned()),
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![
@@ -873,8 +874,8 @@ fn validate_nested_boolean_shapes() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: Some("bo".to_owned()),
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![
@@ -1030,8 +1031,8 @@ fn validate_boolean_with_production_extension() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: Some("bo p".to_owned()),
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![

--- a/threemf2-xsd-validation/tests/combined_validation.rs
+++ b/threemf2-xsd-validation/tests/combined_validation.rs
@@ -10,7 +10,7 @@ use threemf2::{
         beamlattice::{Ball, BallMode, Balls, Beam, BeamLattice, Beams, CapMode},
         build::{Build, Item},
         mesh::{Mesh, Triangle, Triangles, Vertex, Vertices},
-        model::{Model, Unit},
+        model::{Model, ThreemfExtensions, Unit},
         object::{Object, ObjectKind, ObjectType},
         resources::Resources,
         triangle_set::{TriangleRef, TriangleSet, TriangleSets},
@@ -21,6 +21,7 @@ use threemf2::{
         content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
         relationship::{Relationship, RelationshipType, Relationships},
     },
+    threemf_namespaces::ThreemfNamespace,
 };
 
 mod validation_utils;
@@ -172,8 +173,11 @@ fn validate_beamlattice_with_trianglesets() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: Some("b b2".to_owned()),
-            recommendedextensions: Some("t".to_owned()),
+            requiredextensions: ThreemfExtensions::new(&[
+                ThreemfNamespace::BeamLattice,
+                ThreemfNamespace::BeamLatticeBalls,
+            ]),
+            recommendedextensions: ThreemfExtensions::new(&[ThreemfNamespace::CoreTriangleSet]),
             metadata: vec![],
             resources: Resources {
                 object: vec![Object {

--- a/threemf2-xsd-validation/tests/core_validation.rs
+++ b/threemf2-xsd-validation/tests/core_validation.rs
@@ -10,7 +10,7 @@ use threemf2::{
         build::{Build, Item},
         mesh::{Mesh, Triangle, Triangles, Vertex, Vertices},
         metadata::Preserve,
-        model::{Model, Unit},
+        model::{Model, ThreemfExtensions, Unit},
         object::{Object, ObjectKind, ObjectType},
         resources::Resources,
         types::OptionalResourceIndex,
@@ -90,8 +90,8 @@ fn validate_simple_mesh_against_core_xsd() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![Object {
@@ -236,8 +236,8 @@ fn validate_model_with_metadata_against_core_xsd() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![
                 Metadata {
                     name: "Title".to_owned(),
@@ -399,8 +399,8 @@ fn validate_model_with_different_units() {
         let write_package = ThreemfPackage::new(
             Model {
                 unit: Some(unit.clone()),
-                requiredextensions: None,
-                recommendedextensions: None,
+                requiredextensions: ThreemfExtensions::default(),
+                recommendedextensions: ThreemfExtensions::default(),
                 metadata: vec![],
                 resources: Resources {
                     object: vec![Object {

--- a/threemf2-xsd-validation/tests/displacement_validation.rs
+++ b/threemf2-xsd-validation/tests/displacement_validation.rs
@@ -11,7 +11,7 @@ use threemf2::{
             Disp2DCoord, Disp2DGroup, Displacement2D, DisplacementMesh, NormVector,
             NormVectorGroup, Triangle, Triangles, Vertex, Vertices,
         },
-        model::{Model, Unit},
+        model::{Model, ThreemfExtensions, Unit},
         object::{Object, ObjectKind, ObjectType},
         resources::Resources,
     },
@@ -20,6 +20,7 @@ use threemf2::{
         content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
         relationship::{Relationship, RelationshipType, Relationships},
     },
+    threemf_namespaces::ThreemfNamespace,
 };
 
 mod validation_utils;
@@ -32,8 +33,8 @@ const DISPLACEMENT_XSD: &str = include_str!("data/xsd/3mf-displacement-1.0.0.xsd
 fn validate_displacement_model_schema() {
     let model = Model {
         unit: Some(Unit::Millimeter),
-        requiredextensions: Some("d ".to_owned()),
-        recommendedextensions: None,
+        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Displacement]),
+        recommendedextensions: ThreemfExtensions::default(),
         metadata: vec![],
         resources: Resources {
             object: vec![Object {

--- a/threemf2-xsd-validation/tests/material_validation.rs
+++ b/threemf2-xsd-validation/tests/material_validation.rs
@@ -14,7 +14,7 @@ use threemf2::{
             Texture2DGroup, TextureContentType, TileStyle,
         },
         mesh::{Mesh, Triangle, Triangles, Vertex, Vertices},
-        model::{Model, Unit},
+        model::{Model, ThreemfExtensions, Unit},
         object::{Object, ObjectKind, ObjectType},
         resources::Resources,
         types::{Double, ResourceIdCollection, ResourceIndexCollection},
@@ -24,6 +24,7 @@ use threemf2::{
         content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
         relationship::{Relationship, RelationshipType, Relationships},
     },
+    threemf_namespaces::ThreemfNamespace,
 };
 
 mod validation_utils;
@@ -129,8 +130,8 @@ fn validate_simple_colorgroup() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: Some("m".to_owned()),
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Material]),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![Object {
@@ -301,8 +302,8 @@ fn validate_texture2d_with_uv_mapping() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: Some("m".to_owned()),
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Material]),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![Object {
@@ -506,8 +507,8 @@ fn validate_multi_properties() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: Some("m".to_owned()),
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Material]),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![Object {
@@ -676,8 +677,8 @@ fn validate_vertex_color_application() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: Some("m".to_owned()),
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Material]),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![Object {

--- a/threemf2-xsd-validation/tests/production_validation.rs
+++ b/threemf2-xsd-validation/tests/production_validation.rs
@@ -11,7 +11,7 @@ use threemf2::{
         build::{Build, Item},
         component::Component,
         mesh::{Mesh, Triangle, Triangles, Vertex, Vertices},
-        model::{Model, Unit},
+        model::{Model, ThreemfExtensions, Unit},
         object::{Object, ObjectKind, ObjectType},
         resources::Resources,
         types::OptionalResourceIndex,
@@ -21,6 +21,7 @@ use threemf2::{
         content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
         relationship::{Relationship, RelationshipType, Relationships},
     },
+    threemf_namespaces::ThreemfNamespace,
 };
 
 mod validation_utils;
@@ -107,8 +108,8 @@ fn validate_simple_production_model_with_uuids() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: Some("p".to_owned()),
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Prod]),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![Object {
@@ -260,8 +261,8 @@ fn validate_production_model_with_components() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: Some("p".to_owned()),
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Prod]),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![

--- a/threemf2-xsd-validation/tests/slice_validation.rs
+++ b/threemf2-xsd-validation/tests/slice_validation.rs
@@ -10,7 +10,7 @@ use threemf2::{
         OptionalResourceId, OptionalResourceIndex,
         build::{Build, Item},
         mesh::{self, Mesh, Triangle, Triangles, Vertex, Vertices},
-        model::{Model, Unit},
+        model::{Model, ThreemfExtensions, Unit},
         object::{Object, ObjectKind, ObjectType},
         resources::Resources,
         slice::{self, MeshResolution, Polygon, Segment, Slice, SliceStack},
@@ -20,6 +20,7 @@ use threemf2::{
         content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
         relationship::{Relationship, RelationshipType, Relationships},
     },
+    threemf_namespaces::ThreemfNamespace,
 };
 
 mod validation_utils;
@@ -161,8 +162,8 @@ fn validate_simple_slice() {
 
     let model = Model {
         unit: Some(Unit::Millimeter),
-        requiredextensions: Some("s ".to_owned()),
-        recommendedextensions: None,
+        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Slice]),
+        recommendedextensions: ThreemfExtensions::default(),
         metadata: vec![],
         resources: Resources {
             object: vec![object],
@@ -396,8 +397,8 @@ fn validate_slice_multiple_polygons() {
 
     let model = Model {
         unit: Some(Unit::Millimeter),
-        requiredextensions: None, // FullRes doesn't require slice extension
-        recommendedextensions: Some("s ".to_owned()),
+        requiredextensions: ThreemfExtensions::default(), // FullRes doesn't require slice extension
+        recommendedextensions: ThreemfExtensions::new(&[ThreemfNamespace::Slice]),
         metadata: vec![],
         resources: Resources {
             object: vec![object],

--- a/threemf2-xsd-validation/tests/trianglesets_validation.rs
+++ b/threemf2-xsd-validation/tests/trianglesets_validation.rs
@@ -10,7 +10,7 @@ use threemf2::{
         OptionalResourceId,
         build::{Build, Item},
         mesh::{Mesh, Triangle, Triangles, Vertex, Vertices},
-        model::{Model, Unit},
+        model::{Model, ThreemfExtensions, Unit},
         object::{Object, ObjectKind, ObjectType},
         resources::Resources,
         triangle_set::{TriangleRef, TriangleRefRange, TriangleSet, TriangleSets},
@@ -21,6 +21,7 @@ use threemf2::{
         content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
         relationship::{Relationship, RelationshipType, Relationships},
     },
+    threemf_namespaces::ThreemfNamespace,
 };
 
 mod validation_utils;
@@ -122,8 +123,8 @@ fn validate_simple_trianglesets() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: None,
-            recommendedextensions: Some("t".to_owned()),
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::new(&[ThreemfNamespace::CoreTriangleSet]),
             metadata: vec![],
             resources: Resources {
                 object: vec![Object {
@@ -267,8 +268,8 @@ fn validate_trianglesets_with_ref_ranges() {
     let write_package = ThreemfPackage::new(
         Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: None,
-            recommendedextensions: Some("t".to_owned()),
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::new(&[ThreemfNamespace::CoreTriangleSet]),
             metadata: vec![],
             resources: Resources {
                 object: vec![Object {

--- a/threemf2/Cargo.toml
+++ b/threemf2/Cargo.toml
@@ -43,7 +43,6 @@ serde-roxmltree = { version = "0.11.1", optional = true }
 serde = { version = "1.0.228", optional = true, features = ["derive"] }
 once_cell = { version = "1.21.3", optional = true }
 lexical-core = { version = "1.0.6" }
-xmlparser = { version = "0.13.6" }
 
 
 [dev-dependencies]

--- a/threemf2/Cargo.toml
+++ b/threemf2/Cargo.toml
@@ -24,31 +24,34 @@ default = [
 write = ["dep:instant-xml"]
 memory-optimized-read = ["dep:instant-xml"]
 speed-optimized-read = ["dep:serde-roxmltree", "dep:serde"]
-io-write = ["dep:zip", "dep:thiserror", "write"]
-io-memory-optimized-read = ["dep:zip", "dep:thiserror", "memory-optimized-read"]
-io-speed-optimized-read = ["dep:zip", "dep:thiserror", "speed-optimized-read"]
+io-write = ["dep:zip", "write"]
+io-memory-optimized-read = ["dep:zip", "memory-optimized-read"]
+io-speed-optimized-read = ["dep:zip", "speed-optimized-read"]
 io-lazy-read = ["dep:once_cell", "io-memory-optimized-read"]
 # memory-optimized-read-experimental = [
 #     "memory-optimized-read",
 # ] #to dump all experiments
 
 [dependencies]
-instant-xml = { version = "0.6.0", optional = true }
-thiserror = { version = "2.0.3", optional = true }
+instant-xml = { version = "0.7.4", optional = true }
+# instant-xml = { version = "0.7.4", path = "../../../../instant-xml/instant-xml/instant-xml", optional = true }
+thiserror = { version = "2.0.3" }
 zip = { version = "8.4.0", default-features = false, features = [
     "deflate",
 ], optional = true }
-serde-roxmltree = { version = "0.10.0", optional = true }
+serde-roxmltree = { version = "0.11.1", optional = true }
 serde = { version = "1.0.228", optional = true, features = ["derive"] }
 once_cell = { version = "1.21.3", optional = true }
 lexical-core = { version = "1.0.6" }
+xmlparser = { version = "0.13.6" }
 
 
 [dev-dependencies]
 pretty_assertions = { version = "1.4.1" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.140" }
-serde-roxmltree = { version = "0.10.0" }
+serde-roxmltree = { version = "0.11.1" }
+
 
 [[example]]
 name = "write"

--- a/threemf2/examples/beamlattice_write.rs
+++ b/threemf2/examples/beamlattice_write.rs
@@ -5,11 +5,12 @@ use threemf2::{
         build::{Build, Item},
         mesh::{Mesh, Triangles, Vertex, Vertices},
         metadata::Metadata,
-        model::{Model, Unit},
+        model::{Model, ThreemfExtensions, Unit},
         object::{Object, ObjectKind, ObjectType},
         resources::Resources,
     },
     io::ThreemfPackage,
+    threemf_namespaces::ThreemfNamespace,
 };
 
 use std::{io::Cursor, vec};
@@ -225,8 +226,11 @@ fn main() {
     // Create the complete 3MF model
     let model = Model {
         unit: Some(Unit::Millimeter),
-        requiredextensions: Some("b b2".to_string()), // Mark beam lattice extensions as required
-        recommendedextensions: None,
+        requiredextensions: ThreemfExtensions::new(&[
+            ThreemfNamespace::BeamLattice,
+            ThreemfNamespace::BeamLatticeBalls,
+        ]), // Mark beam lattice extensions as required
+        recommendedextensions: ThreemfExtensions::default(),
         metadata: vec![Metadata {
             name: "Beam Lattice Example".to_string(),
             preserve: None,

--- a/threemf2/examples/boolean_write.rs
+++ b/threemf2/examples/boolean_write.rs
@@ -24,11 +24,12 @@ use threemf2::{
         build::{Build, Item},
         mesh::{Mesh, Triangle, Triangles, Vertex, Vertices},
         metadata::Metadata,
-        model::{Model, Unit},
+        model::{Model, ThreemfExtensions, Unit},
         object::{Object, ObjectKind, ObjectType},
         resources::Resources,
     },
     io::ThreemfPackage,
+    threemf_namespaces::ThreemfNamespace,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -366,8 +367,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create the model
     let model = Model {
         unit: Some(Unit::Millimeter),
-        requiredextensions: Some("bo".to_string()), // Boolean extension is required
-        recommendedextensions: None,
+        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]), // Boolean extension is required
+        recommendedextensions: ThreemfExtensions::default(),
         metadata: vec![
             Metadata {
                 name: "Application".to_string(),
@@ -413,9 +414,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\nModel statistics:");
     println!("  Objects: {}", model.resources.object.len());
     println!("  Build items: {}", model.build.item.len());
-    if let Some(ref extensions) = model.requiredextensions {
-        println!("  Required extensions: {}", extensions);
-    }
+    // if let Some(ref extensions) = model.requiredextensions {
+    println!(
+        "  Required extensions: {:?}",
+        model.requiredextensions.get()
+    );
+    // }
 
     // Create 3MF package and write to file
     let package: ThreemfPackage = model.into();

--- a/threemf2/examples/boolean_write.rs
+++ b/threemf2/examples/boolean_write.rs
@@ -414,12 +414,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\nModel statistics:");
     println!("  Objects: {}", model.resources.object.len());
     println!("  Build items: {}", model.build.item.len());
-    // if let Some(ref extensions) = model.requiredextensions {
     println!(
         "  Required extensions: {:?}",
         model.requiredextensions.get()
     );
-    // }
 
     // Create 3MF package and write to file
     let package: ThreemfPackage = model.into();

--- a/threemf2/examples/builder_beamlattice_example.rs
+++ b/threemf2/examples/builder_beamlattice_example.rs
@@ -1,4 +1,4 @@
-use threemf2::io::{BallMode, CapMode, ModelBuilder, ObjectType, Unit};
+use threemf2::core::builder::{BallMode, CapMode, ModelBuilder, ObjectType, Unit};
 
 /// This example demonstrates how to use the BeamLatticeBuilder with ModelBuilder
 /// to create 3MF models with beam lattice structures.

--- a/threemf2/examples/builder_example.rs
+++ b/threemf2/examples/builder_example.rs
@@ -1,4 +1,5 @@
-use threemf2::io::{ModelBuilder, ObjectType, ThreemfPackage, Unit};
+use threemf2::core::builder::{ModelBuilder, ObjectType, Unit};
+use threemf2::io::ThreemfPackage;
 
 /// This example shows how to build 3MF Model using ModelBuilder.
 /// Use this to reduce the boilerplate needed to setup 3MF Models.

--- a/threemf2/examples/core-no-default-features.rs
+++ b/threemf2/examples/core-no-default-features.rs
@@ -3,7 +3,7 @@ use threemf2::core::{
     build::{Build, Item},
     mesh::{Mesh, Triangle, Triangles, Vertex, Vertices},
     metadata::Metadata,
-    model::{Model, Unit},
+    model::{Model, ThreemfExtensions, Unit},
     object::{Object, ObjectKind, ObjectType},
     resources::Resources,
     types::OptionalResourceIndex,
@@ -19,8 +19,8 @@ use std::vec;
 fn main() {
     let model = Model {
         unit: Some(Unit::Inch),
-        requiredextensions: None,
-        recommendedextensions: None,
+        requiredextensions: ThreemfExtensions::default(),
+        recommendedextensions: ThreemfExtensions::default(),
         metadata: vec![Metadata {
             name: "Test metadata".to_string(),
             preserve: None,

--- a/threemf2/examples/slice_write.rs
+++ b/threemf2/examples/slice_write.rs
@@ -3,7 +3,7 @@ use threemf2::{
         OptionalResourceId, OptionalResourceIndex,
         build::{Build, Item},
         mesh::{self, Mesh, Triangle, Triangles, Vertices},
-        model::{Model, Unit},
+        model::{Model, ThreemfExtensions, Unit},
         object::{Object, ObjectKind, ObjectType},
         resources::Resources,
         slice::{self, MeshResolution, Polygon, Segment, Slice, SliceStack},
@@ -13,6 +13,7 @@ use threemf2::{
         content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
         relationship::{Relationship, RelationshipType, Relationships},
     },
+    threemf_namespaces::ThreemfNamespace,
 };
 
 use std::collections::HashMap;
@@ -244,8 +245,8 @@ fn main() {
     // Create the model
     let model = Model {
         unit: Some(Unit::Millimeter),
-        requiredextensions: Some("s ".to_owned()), // Slice extension is required
-        recommendedextensions: None,
+        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Slice]), // Slice extension is required
+        recommendedextensions: ThreemfExtensions::default(),
         metadata: vec![],
         resources,
         build,

--- a/threemf2/examples/write.rs
+++ b/threemf2/examples/write.rs
@@ -4,7 +4,7 @@ use threemf2::{
         build::{Build, Item},
         mesh::*,
         metadata::Metadata,
-        model::{Model, Unit},
+        model::{Model, ThreemfExtensions, Unit},
         object::{Object, ObjectKind, ObjectType},
         resources::Resources,
         types::OptionalResourceIndex,
@@ -22,8 +22,8 @@ use std::{io::Cursor, vec};
 fn main() {
     let model = Model {
         unit: Some(Unit::Inch),
-        requiredextensions: None,
-        recommendedextensions: None,
+        requiredextensions: ThreemfExtensions::default(),
+        recommendedextensions: ThreemfExtensions::default(),
         metadata: vec![Metadata {
             name: "Test metadata".to_string(),
             preserve: None,

--- a/threemf2/src/core/beamlattice.rs
+++ b/threemf2/src/core/beamlattice.rs
@@ -364,7 +364,7 @@ pub struct Beam {
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(BEAM_LATTICE_BALLS_NS), rename = "balls")
+    xml(ns(BEAM_LATTICE_BALLS_NS), rename = "balls", force_prefix)
 )]
 pub struct Balls {
     #[cfg_attr(feature = "speed-optimized-read", serde(default))]
@@ -378,7 +378,7 @@ pub struct Balls {
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(BEAM_LATTICE_BALLS_NS), rename = "ball")
+    xml(ns(BEAM_LATTICE_BALLS_NS), rename = "ball", force_prefix)
 )]
 pub struct Ball {
     /// References a zero-based index into the vertices of this mesh.
@@ -609,10 +609,11 @@ mod write_tests {
     #[test]
     pub fn toxml_beamlattice_with_balls_test() {
         let xml_string = format!(
-            r#"<beamlattice xmlns="{}" xmlns:{}="{}" minlength="0.0001" radius="1" {}:ballmode="mixed" {}:ballradius="0.25" cap="sphere"><beams><beam v1="0" v2="1" r1="1.5" r2="1.6" /></beams><{}:balls><ball vindex="0" r="0.5" /></{}:balls></beamlattice>"#,
+            r#"<beamlattice xmlns="{}" xmlns:{}="{}" minlength="0.0001" radius="1" {}:ballmode="mixed" {}:ballradius="0.25" cap="sphere"><beams><beam v1="0" v2="1" r1="1.5" r2="1.6" /></beams><{}:balls><{}:ball vindex="0" r="0.5" /></{}:balls></beamlattice>"#,
             BEAM_LATTICE_NS,
             BEAM_LATTICE_BALLS_PREFIX,
             BEAM_LATTICE_BALLS_NS,
+            BEAM_LATTICE_BALLS_PREFIX,
             BEAM_LATTICE_BALLS_PREFIX,
             BEAM_LATTICE_BALLS_PREFIX,
             BEAM_LATTICE_BALLS_PREFIX,
@@ -698,13 +699,13 @@ mod memory_optimized_read_tests {
             OptionalResourceIndex,
             build::Build,
             mesh::{Mesh, Triangles, Vertex, Vertices},
-            model::Model,
+            model::{Model, ThreemfExtensions},
             object::{Object, ObjectKind},
             resources::Resources,
         },
         threemf_namespaces::{
             BEAM_LATTICE_BALLS_NS, BEAM_LATTICE_BALLS_PREFIX, BEAM_LATTICE_NS, BEAM_LATTICE_PREFIX,
-            CORE_NS,
+            CORE_NS, ThreemfNamespace,
         },
     };
 
@@ -965,8 +966,11 @@ mod memory_optimized_read_tests {
             mesh,
             Model {
                 unit: None,
-                requiredextensions: Some("b b2".to_owned()),
-                recommendedextensions: None,
+                requiredextensions: ThreemfExtensions::new(&[
+                    ThreemfNamespace::BeamLattice,
+                    ThreemfNamespace::BeamLatticeBalls
+                ]),
+                recommendedextensions: ThreemfExtensions::default(),
                 metadata: vec![],
                 resources: Resources {
                     object: vec![Object {
@@ -1083,13 +1087,13 @@ mod speed_optimized_read_tests {
             OptionalResourceIndex,
             build::Build,
             mesh::{Mesh, Triangles, Vertex, Vertices},
-            model::Model,
+            model::{Model, ThreemfExtensions},
             object::{Object, ObjectKind},
             resources::Resources,
         },
         threemf_namespaces::{
             BEAM_LATTICE_BALLS_NS, BEAM_LATTICE_BALLS_PREFIX, BEAM_LATTICE_NS, BEAM_LATTICE_PREFIX,
-            CORE_NS,
+            CORE_NS, ThreemfNamespace,
         },
     };
 
@@ -1440,8 +1444,12 @@ mod speed_optimized_read_tests {
             mesh,
             Model {
                 unit: None,
-                requiredextensions: Some("b b2".to_owned()),
-                recommendedextensions: None,
+                // requiredextensions: Some("b b2".to_owned()),
+                requiredextensions: ThreemfExtensions::new(&[
+                    ThreemfNamespace::BeamLattice,
+                    ThreemfNamespace::BeamLatticeBalls
+                ]),
+                recommendedextensions: ThreemfExtensions::default(),
                 metadata: vec![],
                 resources: Resources {
                     object: vec![Object {

--- a/threemf2/src/core/boolean.rs
+++ b/threemf2/src/core/boolean.rs
@@ -23,7 +23,7 @@ use crate::{
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(BOOLEAN_NS), rename = "booleanshape")
+    xml(ns(BOOLEAN_NS), rename = "booleanshape", force_prefix)
 )]
 pub struct BooleanShape {
     /// Reference to the base object ID to apply boolean operations.
@@ -79,7 +79,7 @@ pub struct BooleanShape {
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(BOOLEAN_NS), rename = "boolean")
+    xml(ns(BOOLEAN_NS), rename = "boolean", force_prefix)
 )]
 pub struct Boolean {
     /// Reference to the mesh object ID to use as the boolean operand.
@@ -350,7 +350,7 @@ mod write_tests {
         };
 
         let xml_string = format!(
-            r##"<object xmlns="{}" xmlns:{}="{}" xmlns:{}="{}" xmlns:{}="{}" id="100"><bo:booleanshape objectid="95" operation="difference"><boolean objectid="66" /><boolean objectid="213" /></bo:booleanshape></object>"##,
+            r##"<object xmlns="{}" xmlns:{}="{}" xmlns:{}="{}" xmlns:{}="{}" id="100"><bo:booleanshape objectid="95" operation="difference"><bo:boolean objectid="66" /><bo:boolean objectid="213" /></bo:booleanshape></object>"##,
             CORE_NS, BOOLEAN_PREFIX, BOOLEAN_NS, PROD_PREFIX, PROD_NS, SLICE_PREFIX, SLICE_NS,
         );
 

--- a/threemf2/src/core/builder.rs
+++ b/threemf2/src/core/builder.rs
@@ -127,24 +127,16 @@ use crate::{
         component::{Component, Components},
         mesh::{Mesh, Triangle, Triangles, Vertex, Vertices},
         metadata::Metadata,
-        model::Model,
+        model::{Model, ThreemfExtensions},
         object::{Object, ObjectKind},
         resources::Resources,
         slice::{self, MeshResolution, Polygon, Segment, Slice, SliceRef, SliceStack},
         transform::Transform,
     },
-    io::XmlNamespace,
-    threemf_namespaces::{
-        BEAM_LATTICE_BALLS_NS, BEAM_LATTICE_BALLS_PREFIX, BEAM_LATTICE_NS, BEAM_LATTICE_PREFIX,
-        BOOLEAN_NS, BOOLEAN_PREFIX, CORE_TRIANGLESET_NS, CORE_TRIANGLESET_PREFIX, PROD_NS,
-        PROD_PREFIX, SLICE_NS, SLICE_PREFIX,
-    },
+    threemf_namespaces::ThreemfNamespace,
 };
 
-use std::{
-    collections::HashSet,
-    ops::{Deref, DerefMut},
-};
+use std::ops::{Deref, DerefMut};
 
 pub use crate::core::beamlattice::{BallMode, CapMode, ClippingMode};
 pub use crate::core::model::Unit;
@@ -324,8 +316,8 @@ pub enum ProductionExtensionError {
 /// ```
 pub struct ModelBuilder {
     unit: Option<Unit>,
-    requiredextensions: Vec<XmlNamespace>,
-    recommendedextensions: Vec<XmlNamespace>,
+    requiredextensions: Vec<ThreemfNamespace>,
+    recommendedextensions: Vec<ThreemfNamespace>,
     metadata: Vec<Metadata>,
     resources: ResourcesBuilder,
     build: Option<BuildBuilder>, //in submodels, Build item is not allowed
@@ -465,18 +457,28 @@ impl ModelBuilder {
     ///
     /// Required extensions must be understood by readers to process the file.
     /// Some extensions are automatically added based on features used (e.g., beam lattice).
-    pub fn add_required_extension(&mut self, extension: XmlNamespace) -> &mut Self {
-        self.requiredextensions.push(extension);
-        self
+    pub fn add_required_extension(&mut self, extension: ThreemfNamespace) -> &mut Self {
+        match extension {
+            ThreemfNamespace::Core => self,
+            _ => {
+                self.requiredextensions.push(extension);
+                self
+            }
+        }
     }
 
     /// Add a recommended 3MF extension to the model.
     ///
     /// Recommended extensions can be ignored by readers if not supported.
     /// Some extensions are automatically added based on features used (e.g., triangle sets).
-    pub fn add_recommended_extension(&mut self, extension: XmlNamespace) -> &mut Self {
-        self.recommendedextensions.push(extension);
-        self
+    pub fn add_recommended_extension(&mut self, extension: ThreemfNamespace) -> &mut Self {
+        match extension {
+            ThreemfNamespace::Core => self,
+            _ => {
+                self.recommendedextensions.push(extension);
+                self
+            }
+        }
     }
 
     /// Add metadata key-value pair to the model.
@@ -908,8 +910,8 @@ impl ModelBuilder {
     pub fn build(self) -> Result<Model, ModelError> {
         let required_extensions = self.process_required_extensions();
 
-        let requiredextensions = get_extensions_definition(&required_extensions);
-        let recommendedextensions = get_extensions_definition(&self.recommendedextensions);
+        let requiredextensions = ThreemfExtensions::new(&required_extensions);
+        let recommendedextensions = ThreemfExtensions::new(&self.recommendedextensions);
 
         if self.is_root && self.build.is_none() {
             return Err(ModelError::BuildItemNotSet);
@@ -943,24 +945,21 @@ impl ModelBuilder {
             && self
                 .recommendedextensions
                 .iter()
-                .all(|ns| ns.uri == CORE_TRIANGLESET_NS)
+                .all(|ns| *ns == ThreemfNamespace::CoreTriangleSet)
         {
-            self.recommendedextensions.push(XmlNamespace {
-                prefix: Some(CORE_TRIANGLESET_PREFIX.to_owned()),
-                uri: CORE_TRIANGLESET_NS.to_owned(),
-            });
+            self.recommendedextensions
+                .push(ThreemfNamespace::CoreTriangleSet);
         }
     }
 
-    fn process_required_extensions(&self) -> Vec<XmlNamespace> {
+    fn process_required_extensions(&self) -> Vec<ThreemfNamespace> {
         let mut required_extensions = self.requiredextensions.clone();
         if self.is_production_ext_required {
-            let is_prod_ext_set = required_extensions.iter().find(|ns| ns.uri == PROD_NS);
+            let is_prod_ext_set = required_extensions
+                .iter()
+                .find(|ns| **ns == ThreemfNamespace::Prod);
             if is_prod_ext_set.is_none() {
-                required_extensions.push(XmlNamespace {
-                    prefix: Some(PROD_PREFIX.to_owned()),
-                    uri: PROD_NS.to_owned(),
-                });
+                required_extensions.push(ThreemfNamespace::Prod);
             }
         }
 
@@ -968,11 +967,6 @@ impl ModelBuilder {
         let mut is_beam_lattice_balls_required = false;
 
         for object in &self.resources.objects {
-            //early exit to speed up things
-            if is_beam_lattice_balls_required {
-                break;
-            }
-
             if let Some(mesh) = object.get_mesh()
                 && let Some(beam_lattice) = &mesh.beamlattice
             {
@@ -984,23 +978,17 @@ impl ModelBuilder {
         if is_beam_lattice_required {
             let is_bl_ext_set = required_extensions
                 .iter()
-                .find(|ns| ns.uri == BEAM_LATTICE_NS);
+                .find(|ns| **ns == ThreemfNamespace::BeamLattice);
             if is_bl_ext_set.is_none() {
-                required_extensions.push(XmlNamespace {
-                    prefix: Some(BEAM_LATTICE_PREFIX.to_owned()),
-                    uri: BEAM_LATTICE_NS.to_owned(),
-                });
+                required_extensions.push(ThreemfNamespace::BeamLattice);
             }
 
             if is_beam_lattice_balls_required {
                 let is_bl_balls_ext_set = required_extensions
                     .iter()
-                    .find(|ns| ns.uri == BEAM_LATTICE_BALLS_NS);
+                    .find(|ns| **ns == ThreemfNamespace::BeamLatticeBalls);
                 if is_bl_balls_ext_set.is_none() {
-                    required_extensions.push(XmlNamespace {
-                        prefix: Some(BEAM_LATTICE_BALLS_PREFIX.to_owned()),
-                        uri: BEAM_LATTICE_BALLS_NS.to_owned(),
-                    });
+                    required_extensions.push(ThreemfNamespace::BeamLatticeBalls);
                 }
             }
         }
@@ -1013,12 +1001,11 @@ impl ModelBuilder {
             .any(|obj| obj.get_boolean_shape_object().is_some());
 
         if is_boolean_required {
-            let is_boolean_ext_set = required_extensions.iter().find(|ns| ns.uri == BOOLEAN_NS);
+            let is_boolean_ext_set = required_extensions
+                .iter()
+                .find(|ns| **ns == ThreemfNamespace::Boolean);
             if is_boolean_ext_set.is_none() {
-                required_extensions.push(XmlNamespace {
-                    prefix: Some(BOOLEAN_PREFIX.to_owned()),
-                    uri: BOOLEAN_NS.to_owned(),
-                });
+                required_extensions.push(ThreemfNamespace::Boolean);
             }
         }
 
@@ -1030,12 +1017,11 @@ impl ModelBuilder {
             });
 
         if is_slice_required {
-            let is_slice_ext_set = required_extensions.iter().find(|ns| ns.uri == SLICE_NS);
+            let is_slice_ext_set = required_extensions
+                .iter()
+                .find(|ns| **ns == ThreemfNamespace::Slice);
             if is_slice_ext_set.is_none() {
-                required_extensions.push(XmlNamespace {
-                    prefix: Some(SLICE_PREFIX.to_owned()),
-                    uri: SLICE_NS.to_owned(),
-                });
+                required_extensions.push(ThreemfNamespace::Slice);
             }
         }
 
@@ -1046,28 +1032,6 @@ impl ModelBuilder {
 impl Default for ModelBuilder {
     fn default() -> Self {
         Self::new(Unit::Millimeter, true)
-    }
-}
-
-fn get_extensions_definition(extensions: &[XmlNamespace]) -> Option<String> {
-    if extensions.is_empty() {
-        None
-    } else {
-        let mut extension_string = String::new();
-        let mut unique_namespaces: HashSet<XmlNamespace> = HashSet::new();
-
-        for ns in extensions {
-            unique_namespaces.insert(ns.clone());
-        }
-
-        for ns in unique_namespaces {
-            if let Some(prefix) = &ns.prefix {
-                extension_string.push_str(prefix);
-                extension_string.push(' ');
-            }
-        }
-
-        Some(extension_string)
     }
 }
 
@@ -3237,7 +3201,11 @@ mod tests {
             })
             .unwrap();
         let model = builder.build().unwrap();
-        assert_eq!(model.requiredextensions, Some("p ".to_string()));
+
+        assert_eq!(
+            model.requiredextensions,
+            ThreemfExtensions::new(&[ThreemfNamespace::Prod])
+        );
     }
 
     #[test]
@@ -3333,20 +3301,35 @@ mod tests {
     }
 
     #[test]
-    fn test_extension_tests() {
+    fn test_custom_extensions() {
         let mut builder = ModelBuilder::new(Unit::Millimeter, true);
-        builder.add_required_extension(crate::io::XmlNamespace {
-            prefix: Some("test".to_string()),
-            uri: "http://example.com/test".to_string(),
+
+        builder.add_required_extension(ThreemfNamespace::Unknown {
+            prefix: "test".to_owned(),
+            uri: "http://example.com/test".to_owned(),
         });
-        builder.add_recommended_extension(crate::io::XmlNamespace {
-            prefix: Some("rec".to_string()),
-            uri: "http://example.com/rec".to_string(),
+
+        builder.add_recommended_extension(ThreemfNamespace::Unknown {
+            prefix: "rec".to_owned(),
+            uri: "http://example.com/rec".to_owned(),
         });
         builder.add_build(None).unwrap();
         let model = builder.build().unwrap();
-        assert_eq!(model.requiredextensions, Some("test ".to_string()));
-        assert_eq!(model.recommendedextensions, Some("rec ".to_string()));
+
+        assert_eq!(
+            model.requiredextensions,
+            ThreemfExtensions::new(&[ThreemfNamespace::Unknown {
+                prefix: "test".to_owned(),
+                uri: "http://example.com/test".to_owned()
+            }])
+        );
+        assert_eq!(
+            model.recommendedextensions,
+            ThreemfExtensions::new(&[ThreemfNamespace::Unknown {
+                prefix: "rec".to_owned(),
+                uri: "http://example.com/rec".to_owned()
+            }])
+        );
     }
 
     #[test]
@@ -3609,7 +3592,10 @@ mod tests {
         assert_eq!(sets[1].triangle_refrange.len(), 2);
 
         //check if Triangle set is in recommended extensions
-        assert_eq!(model.recommendedextensions, Some("t ".to_owned()))
+        assert_eq!(
+            model.recommendedextensions,
+            ThreemfExtensions::new(&[ThreemfNamespace::CoreTriangleSet])
+        );
     }
 
     #[test]
@@ -3933,7 +3919,10 @@ mod tests {
         let mesh = obj.get_mesh().unwrap();
         assert!(mesh.beamlattice.is_some());
 
-        assert_eq!(model.requiredextensions, Some("b ".to_owned()));
+        assert_eq!(
+            model.requiredextensions,
+            ThreemfExtensions::new(&[ThreemfNamespace::BeamLattice,])
+        );
     }
 
     #[test]
@@ -3964,12 +3953,12 @@ mod tests {
         let bl = mesh.beamlattice.as_ref().unwrap();
         assert!(bl.balls.is_some());
 
-        let prefixes = ["b", "b2"];
-        if let Some(exts) = &model.requiredextensions {
-            let split_exts = exts.split_whitespace().collect::<Vec<_>>();
-            for prefix in prefixes {
-                assert!(split_exts.contains(&prefix));
-            }
-        }
+        assert_eq!(
+            model.requiredextensions,
+            ThreemfExtensions::new(&[
+                ThreemfNamespace::BeamLatticeBalls,
+                ThreemfNamespace::BeamLattice,
+            ])
+        )
     }
 }

--- a/threemf2/src/core/component.rs
+++ b/threemf2/src/core/component.rs
@@ -22,7 +22,7 @@ use crate::{
 #[derive(PartialEq, Debug, Clone)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(CORE_NS), rename = "components")
+    xml(ns(CORE_NS, p=PROD_NS), rename = "components")
 )]
 pub struct Components {
     pub component: Vec<Component>,
@@ -118,8 +118,8 @@ mod write_tests {
     #[test]
     pub fn toxml_components_test() {
         let xml_string = format!(
-            r#"<components xmlns="{}"><component xmlns:{}="{}" objectid="4" transform="1.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 1.000000 35.000000 35.000000 5.100000" /><component xmlns:{}="{}" objectid="5" /></components>"#,
-            CORE_NS, PROD_PREFIX, PROD_NS, PROD_PREFIX, PROD_NS
+            r#"<components xmlns="{}" xmlns:{}="{}"><component objectid="4" transform="1.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 1.000000 35.000000 35.000000 5.100000" /><component objectid="5" /></components>"#,
+            CORE_NS, PROD_PREFIX, PROD_NS,
         );
         let components = Components {
             component: vec![

--- a/threemf2/src/core/constants.rs
+++ b/threemf2/src/core/constants.rs
@@ -1,4 +1,4 @@
 #[cfg(feature = "memory-optimized-read")]
-pub const MAX_VERTEX_BUFFER: usize = 100_000;
+pub const MAX_VERTEX_BUFFER: usize = 1000;
 #[cfg(feature = "memory-optimized-read")]
-pub const MAX_TRIANGLE_BUFFER: usize = 200_000;
+pub const MAX_TRIANGLE_BUFFER: usize = 2000;

--- a/threemf2/src/core/material.rs
+++ b/threemf2/src/core/material.rs
@@ -156,7 +156,7 @@ impl From<String> for BlendMethod {
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(MATERIAL_NS), rename = "colorgroup")
+    xml(ns(MATERIAL_NS), rename = "colorgroup", force_prefix)
 )]
 pub struct ColorGroup {
     /// Unique identifier for this color group.
@@ -182,7 +182,7 @@ pub struct ColorGroup {
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(MATERIAL_NS), rename = "color")
+    xml(ns(MATERIAL_NS), rename = "color", force_prefix)
 )]
 pub struct ColorElement {
     /// The sRGB color value as a hex string (e.g., "#FF0000" or "#FF0000FF").
@@ -204,7 +204,7 @@ pub struct ColorElement {
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(MATERIAL_NS), rename = "texture2dgroup")
+    xml(ns(MATERIAL_NS), rename = "texture2dgroup", force_prefix)
 )]
 pub struct Texture2DGroup {
     /// Unique identifier for this texture coordinate group.
@@ -234,7 +234,10 @@ pub struct Texture2DGroup {
 #[cfg_attr(feature = "speed-optimized-read", serde(rename = "tex2coord"))]
 #[cfg_attr(feature = "write", derive(ToXml))]
 #[derive(Debug, PartialEq, Clone, Copy)]
-#[cfg_attr(feature = "write", xml(ns(MATERIAL_NS), rename = "tex2coord"))]
+#[cfg_attr(
+    feature = "write",
+    xml(ns(MATERIAL_NS), rename = "tex2coord", force_prefix)
+)]
 pub struct Tex2Coord {
     /// Horizontal coordinate (u-axis), increasing right from the origin.
     #[cfg_attr(feature = "write", xml(attribute))]
@@ -313,7 +316,7 @@ impl<'xml> FromXml<'xml> for Tex2Coord {
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(MATERIAL_NS), rename = "compositematerials")
+    xml(ns(MATERIAL_NS), rename = "compositematerials", force_prefix)
 )]
 pub struct CompositeMaterials {
     /// Unique identifier for this composite material group.
@@ -386,16 +389,17 @@ impl ToXml for Composite {
         field: Option<instant_xml::Id<'_>>,
         serializer: &mut instant_xml::Serializer<W>,
     ) -> Result<(), instant_xml::Error> {
-        let ns = match field {
-            Some(id) => {
-                serializer.write_start(id.name, id.ns)?;
-                id.ns
-            }
-            None => {
-                serializer.write_start("composite", MATERIAL_NS)?;
-                "" //return no namespace in this case because there are no prefix for attr
-            }
+        let (name, ns) = match field {
+            Some(id) => (id.name, id.ns),
+            None => ("composite", MATERIAL_NS),
         };
+
+        // Force prefix usage for material namespace
+        let mut cx = instant_xml::ser::Context::<0>::default();
+        cx.default_ns = MATERIAL_NS;
+        cx.force_prefix = true;
+
+        serializer.write_start(name, ns, Some(cx))?;
 
         if !self.values.is_empty() {
             let values_str = self
@@ -480,7 +484,7 @@ impl<'xml> instant_xml::FromXml<'xml> for Composite {
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(MATERIAL_NS), rename = "multiproperties")
+    xml(ns(MATERIAL_NS), rename = "multiproperties", force_prefix)
 )]
 pub struct MultiProperties {
     /// Unique identifier for this multi-property group.
@@ -522,7 +526,7 @@ pub struct MultiProperties {
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(MATERIAL_NS), rename = "multi")
+    xml(ns(MATERIAL_NS), rename = "multi", force_prefix)
 )]
 pub struct Multi {
     /// Space-delimited list of property indices.
@@ -632,7 +636,7 @@ impl TextureContentType {
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(MATERIAL_NS), rename = "texture2d")
+    xml(ns(MATERIAL_NS), rename = "texture2d", force_prefix)
 )]
 pub struct Texture2D {
     /// Unique identifier for this texture resource.

--- a/threemf2/src/core/metadata.rs
+++ b/threemf2/src/core/metadata.rs
@@ -43,36 +43,26 @@ impl ToXml for Metadata {
         &self,
         field: Option<instant_xml::Id<'_>>,
         serializer: &mut instant_xml::Serializer<W>,
-    ) -> Result<(), Error> {
-        // let id = field.unwrap_or(instant_xml::Id {
-        //     name: "metadata",
-        //     ns: CORE_NS,
-        // });
-
+    ) -> Result<(), instant_xml::Error> {
         let (name, ns) = match field {
             Some(field) => (field.name, field.ns),
             None => ("metadata", CORE_NS),
         };
 
-        let _ = serializer.write_start(name, ns)?;
+        let mut cx = instant_xml::ser::Context::<0>::default();
+        cx.default_ns = CORE_NS;
 
-        if field.is_none() {
-            let _ = serializer.push(instant_xml::ser::Context {
-                default_ns: CORE_NS,
-                prefixes: [],
-            });
-        }
+        let element = serializer.write_start(name, ns, Some(cx))?;
 
-        serializer.write_attr("name", ns, &self.name)?;
+        serializer.write_attr("name", CORE_NS, &self.name)?;
         if let Some(preserve) = &self.preserve {
-            serializer.write_attr("preserve", ns, &preserve.0)?;
+            serializer.write_attr("preserve", CORE_NS, &preserve.0)?;
         }
 
-        // Write value as text content if present
         if let Some(value) = &self.value {
             serializer.end_start()?;
             serializer.write_str(value)?;
-            serializer.write_close(None, name)?;
+            serializer.write_close(element)?;
         } else {
             serializer.end_empty()?;
         }

--- a/threemf2/src/core/metadata.rs
+++ b/threemf2/src/core/metadata.rs
@@ -12,7 +12,6 @@ use serde::Deserialize;
 
 use crate::threemf_namespaces::CORE_NS;
 
-//ToDo: Add additional optional fields on Metadata
 /// Key-value metadata associated with a 3MF model or object.
 ///
 /// Metadata provides additional information about the model, such as author,

--- a/threemf2/src/core/mod.rs
+++ b/threemf2/src/core/mod.rs
@@ -48,4 +48,6 @@ pub use types::{
     ResourceIndex, ResourceIndexCollection,
 };
 
+pub mod builder;
+
 mod constants;

--- a/threemf2/src/core/model.rs
+++ b/threemf2/src/core/model.rs
@@ -232,7 +232,6 @@ impl From<String> for ThreemfExtensions {
     }
 }
 
-// #[cfg(feature = "write")]
 impl Model {
     pub fn used_namespaces(&self) -> Vec<ThreemfNamespace> {
         let mut used = vec![ThreemfNamespace::Core];

--- a/threemf2/src/core/model.rs
+++ b/threemf2/src/core/model.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 #[cfg(feature = "write")]
 use instant_xml::ToXml;
 
@@ -38,13 +40,15 @@ pub struct Model {
         any(feature = "write", feature = "memory-optimized-read"),
         xml(attribute)
     )]
-    pub requiredextensions: Option<String>,
+    #[cfg_attr(feature = "speed-optimized-read", serde(default))]
+    pub requiredextensions: ThreemfExtensions,
 
     #[cfg_attr(
         any(feature = "write", feature = "memory-optimized-read"),
         xml(attribute)
     )]
-    pub recommendedextensions: Option<String>,
+    #[cfg_attr(feature = "speed-optimized-read", serde(default))]
+    pub recommendedextensions: ThreemfExtensions,
 
     #[cfg_attr(feature = "speed-optimized-read", serde(default))]
     pub metadata: Vec<Metadata>,
@@ -88,7 +92,147 @@ impl From<String> for Unit {
     }
 }
 
+/// A collection of [`ThreemfNamespace`] specified in the 3mf model file
+/// Only Extension namespaces are allowed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "speed-optimized-read", derive(Deserialize))]
+#[cfg_attr(feature = "speed-optimized-read", serde(from = "String"))]
+pub struct ThreemfExtensions(Vec<ThreemfNamespace>);
+
+impl ThreemfExtensions {
+    /// Creates a new [ThreemfExtensions] collection without duplicate
+    /// extensions and without [`ThreemfNamespace::Core`] included
+    pub fn new(extensions: &[ThreemfNamespace]) -> Self {
+        let mut ordered = extensions
+            .iter()
+            .filter(|ext| **ext != ThreemfNamespace::Core)
+            .cloned()
+            .collect::<Vec<_>>();
+        ordered.sort();
+        ordered.dedup();
+        Self(ordered)
+    }
+
+    /// Creates a new [ThreemfExtensions] collection without duplicate
+    /// extensions and without [`ThreemfNamespace::Core`] included
+    pub fn new_from_iter<'a>(extensions: impl IntoIterator<Item = &'a ThreemfNamespace>) -> Self {
+        let mut ordered = extensions
+            .into_iter()
+            .filter(|ext| **ext != ThreemfNamespace::Core)
+            .cloned()
+            .collect::<Vec<_>>();
+        ordered.sort();
+        ordered.dedup();
+        Self(ordered)
+    }
+
+    /// Returns a slice of the collection
+    pub fn get(&self) -> &[ThreemfNamespace] {
+        &self.0
+    }
+}
+
 #[cfg(feature = "write")]
+impl ToXml for ThreemfExtensions {
+    fn serialize<W: std::fmt::Write + ?Sized>(
+        &self,
+        field: Option<instant_xml::Id<'_>>,
+        serializer: &mut instant_xml::Serializer<W>,
+    ) -> Result<(), instant_xml::Error> {
+        let prefix = match field {
+            Some(id) => {
+                let prefix =
+                    serializer.write_start(id.name, id.ns, None::<instant_xml::ser::Context<0>>)?;
+                serializer.end_start()?;
+                Some((prefix, id.name))
+            }
+            None => None,
+        };
+
+        let mut iter = self
+            .0
+            .iter()
+            .map(|ns| {
+                ns.prefix()
+                    .expect("3mf Extensions collection should be specified with valid prefix")
+            })
+            .peekable();
+        while let Some(prefix) = iter.next() {
+            serializer.write_str(prefix)?;
+            if iter.peek().is_some() {
+                serializer.write_str(" ")?;
+            }
+        }
+
+        if let Some((prefix, _)) = prefix {
+            serializer.write_close(prefix)?;
+        }
+
+        Ok(())
+    }
+
+    fn present(&self) -> bool {
+        !self.0.is_empty()
+    }
+}
+
+#[cfg(feature = "memory-optimized-read")]
+impl<'xml> FromXml<'xml> for ThreemfExtensions {
+    fn matches(id: instant_xml::Id<'_>, field: Option<instant_xml::Id<'_>>) -> bool {
+        match field {
+            Some(field) => id == field,
+            None => false,
+        }
+    }
+
+    fn deserialize<'cx>(
+        into: &mut Self::Accumulator,
+        _field: &'static str,
+        deserializer: &mut instant_xml::Deserializer<'cx, 'xml>,
+    ) -> Result<(), instant_xml::Error> {
+        if let Some(value) = deserializer.take_str()? {
+            let mut ns_collection = vec![];
+            for prefix in value.split_whitespace() {
+                if let Some(uri) = deserializer.namespace(prefix)
+                    && let Some(ns) = ThreemfNamespace::try_from_uri(uri, Some(prefix))
+                {
+                    ns_collection.push(ns);
+                }
+            }
+            *into = Self(ns_collection);
+        } else {
+            *into = Self(vec![]);
+        }
+
+        Ok(())
+    }
+
+    type Accumulator = Self;
+
+    const KIND: instant_xml::Kind = instant_xml::Kind::Scalar;
+}
+
+#[cfg(feature = "memory-optimized-read")]
+impl instant_xml::Accumulate<ThreemfExtensions> for ThreemfExtensions {
+    fn try_done(self, _: &'static str) -> Result<ThreemfExtensions, instant_xml::Error> {
+        Ok(self)
+    }
+}
+
+impl From<String> for ThreemfExtensions {
+    fn from(value: String) -> Self {
+        let mut ns_collection = vec![];
+        for prefix in value.split_whitespace() {
+            if let Some(ns) = ThreemfNamespace::try_from_prefix(prefix, None) {
+                ns_collection.push(ns);
+            }
+        }
+
+        Self(ns_collection)
+    }
+}
+
+// #[cfg(feature = "write")]
 impl Model {
     pub fn used_namespaces(&self) -> Vec<ThreemfNamespace> {
         let mut used = vec![ThreemfNamespace::Core];
@@ -126,6 +270,10 @@ impl Model {
             used.push(ThreemfNamespace::Displacement);
         }
 
+        for ns in self.used_unknown_namespaces() {
+            used.push(ns);
+        }
+
         used
     }
 
@@ -161,11 +309,16 @@ impl Model {
 
     fn uses_beamlattice_ns(&self) -> bool {
         for obj in &self.resources.object {
-            if let Some(kind) = &obj.kind
-                && let ObjectKind::Mesh(mesh) = kind
-                && mesh.beamlattice.is_some()
-            {
-                return true;
+            if let Some(kind) = &obj.kind {
+                if let ObjectKind::Mesh(mesh) = kind
+                    && mesh.beamlattice.is_some()
+                {
+                    return true;
+                } else if let ObjectKind::DisplacementMesh(mesh) = kind
+                    && mesh.beamlattice.is_some()
+                {
+                    return true;
+                }
             }
         }
 
@@ -174,14 +327,22 @@ impl Model {
 
     fn uses_beamlattice_balls_ns(&self) -> bool {
         for obj in &self.resources.object {
-            if let Some(kind) = &obj.kind
-                && let ObjectKind::Mesh(mesh) = kind
-                && let Some(beam_lattice) = &mesh.beamlattice
-                && (beam_lattice.balls.is_some()
-                    || beam_lattice.ballmode.is_some()
-                    || beam_lattice.ballradius.is_some())
-            {
-                return true;
+            if let Some(kind) = &obj.kind {
+                if let ObjectKind::Mesh(mesh) = kind
+                    && let Some(beam_lattice) = &mesh.beamlattice
+                    && (beam_lattice.balls.is_some()
+                        || beam_lattice.ballmode.is_some()
+                        || beam_lattice.ballradius.is_some())
+                {
+                    return true;
+                } else if let ObjectKind::DisplacementMesh(mesh) = kind
+                    && let Some(beam_lattice) = &mesh.beamlattice
+                    && (beam_lattice.balls.is_some()
+                        || beam_lattice.ballmode.is_some()
+                        || beam_lattice.ballradius.is_some())
+                {
+                    return true;
+                }
             }
         }
 
@@ -190,11 +351,16 @@ impl Model {
 
     fn uses_triangleset_ns(&self) -> bool {
         for obj in &self.resources.object {
-            if let Some(kind) = &obj.kind
-                && let ObjectKind::Mesh(mesh) = kind
-                && mesh.trianglesets.is_some()
-            {
-                return true;
+            if let Some(kind) = &obj.kind {
+                if let ObjectKind::Mesh(mesh) = kind
+                    && mesh.trianglesets.is_some()
+                {
+                    return true;
+                } else if let ObjectKind::DisplacementMesh(mesh) = kind
+                    && mesh.trianglesets.is_some()
+                {
+                    return true;
+                }
             }
         }
 
@@ -242,6 +408,28 @@ impl Model {
                 }
             })
     }
+
+    fn used_unknown_namespaces(&self) -> HashSet<ThreemfNamespace> {
+        let mut unknown_set = HashSet::new();
+
+        self.requiredextensions
+            .0
+            .iter()
+            .filter(|ns| matches!(ns, ThreemfNamespace::Unknown { prefix: _, uri: _ }))
+            .for_each(|ns| {
+                unknown_set.insert(ns.clone());
+            });
+
+        self.recommendedextensions
+            .0
+            .iter()
+            .filter(|ns| matches!(ns, ThreemfNamespace::Unknown { prefix: _, uri: _ }))
+            .for_each(|ns| {
+                unknown_set.insert(ns.clone());
+            });
+
+        unknown_set
+    }
 }
 
 #[cfg(feature = "write")]
@@ -263,6 +451,7 @@ mod write_tests {
             },
             mesh::{Mesh, Triangles, Vertices},
             metadata::Metadata,
+            model::ThreemfExtensions,
             object::{Object, ObjectKind, ObjectType},
             resources::Resources,
             slice::{self},
@@ -299,8 +488,8 @@ mod write_tests {
         );
         let model = Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![Metadata {
                 name: "Trial Metadata".to_owned(),
                 preserve: None,
@@ -375,8 +564,8 @@ mod write_tests {
     fn test_used_namespaces_simple_model() {
         let model = Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![Object {
@@ -429,8 +618,8 @@ mod write_tests {
     fn test_used_namespaces_with_prod() {
         let model = Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 basematerials: vec![],
@@ -488,8 +677,8 @@ mod write_tests {
 
         let model = Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 basematerials: vec![],
@@ -561,8 +750,8 @@ mod write_tests {
 
         let model = Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 basematerials: vec![],
@@ -638,8 +827,8 @@ mod write_tests {
 
         let model = Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 basematerials: vec![],
@@ -697,8 +886,8 @@ mod write_tests {
     fn test_used_namespaces_with_boolean_object() {
         let model = Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![Object {
@@ -755,8 +944,8 @@ mod write_tests {
     fn test_used_namespaces_with_slices() {
         let model = Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 object: vec![],
@@ -807,8 +996,8 @@ mod write_tests {
 
         let model = Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 basematerials: vec![],
@@ -910,8 +1099,8 @@ mod write_tests {
     fn test_used_namespaces_with_material() {
         let model = Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 basematerials: vec![],
@@ -976,8 +1165,8 @@ mod write_tests {
     fn test_used_namespaces_with_displacement() {
         let model = Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 basematerials: vec![],
@@ -1017,7 +1206,7 @@ mod write_tests {
         // Note: The serializer always includes all namespace declarations
         // The actual order is: core, b, bo, d, m, p, s, t (alphabetical by prefix)
         let xml_string = format!(
-            r##"<model xmlns="{}" xmlns:{}="{}" xmlns:{}="{}" xmlns:{}="{}" xmlns:{}="{}" xmlns:{}="{}" xmlns:{}="{}" xmlns:{}="{}" unit="millimeter"><resources><{}:colorgroup id="1"><color color="#FF0000FF" /></{}:colorgroup><{}:texture2d id="2" path="/3D/texture.png" contenttype="image/png" /></resources><build></build></model>"##,
+            r##"<model xmlns="{}" xmlns:{}="{}" xmlns:{}="{}" xmlns:{}="{}" xmlns:{}="{}" xmlns:{}="{}" xmlns:{}="{}" xmlns:{}="{}" unit="millimeter"><resources><{}:colorgroup id="1"><{}:color color="#FF0000FF" /></{}:colorgroup><{}:texture2d id="2" path="/3D/texture.png" contenttype="image/png" /></resources><build></build></model>"##,
             CORE_NS,
             BEAM_LATTICE_PREFIX,
             BEAM_LATTICE_NS,
@@ -1035,12 +1224,13 @@ mod write_tests {
             CORE_TRIANGLESET_NS,
             MATERIAL_PREFIX,
             MATERIAL_PREFIX,
-            MATERIAL_PREFIX
+            MATERIAL_PREFIX,
+            MATERIAL_PREFIX,
         );
         let model = Model {
             unit: Some(Unit::Millimeter),
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: Resources {
                 basematerials: vec![],
@@ -1088,6 +1278,7 @@ mod memory_optimized_read_tests {
     use crate::core::OptionalResourceId;
     use crate::core::OptionalResourceIndex;
     use crate::core::material::TextureContentType;
+    use crate::core::model::ThreemfExtensions;
     use crate::{
         core::{
             Color,
@@ -1116,8 +1307,8 @@ mod memory_optimized_read_tests {
             model,
             Model {
                 unit: None, //ToDo: Set the default value when unit is not supplied.
-                requiredextensions: None,
-                recommendedextensions: None,
+                requiredextensions: ThreemfExtensions::default(),
+                recommendedextensions: ThreemfExtensions::default(),
                 metadata: vec![Metadata {
                     name: "Trial Metadata".to_owned(),
                     preserve: None,
@@ -1184,8 +1375,8 @@ mod memory_optimized_read_tests {
             Model {
                 // xmlns: None,
                 unit: Some(Unit::Millimeter),
-                requiredextensions: None,
-                recommendedextensions: None,
+                requiredextensions: ThreemfExtensions::default(),
+                recommendedextensions: ThreemfExtensions::default(),
                 metadata: vec![Metadata {
                     name: "Trial Metadata".to_owned(),
                     preserve: None,
@@ -1284,8 +1475,8 @@ mod memory_optimized_read_tests {
             model,
             Model {
                 unit: Some(Unit::Millimeter),
-                requiredextensions: None,
-                recommendedextensions: None,
+                requiredextensions: ThreemfExtensions::default(),
+                recommendedextensions: ThreemfExtensions::default(),
                 metadata: vec![],
                 resources: Resources {
                     basematerials: vec![],
@@ -1335,6 +1526,7 @@ mod speed_optimized_read_tests {
             component::{Component, Components},
             material::{ColorElement, ColorGroup, Texture2D, TextureContentType},
             metadata::Metadata,
+            model::ThreemfExtensions,
             object::{Object, ObjectKind, ObjectType},
             resources::Resources,
         },
@@ -1357,8 +1549,8 @@ mod speed_optimized_read_tests {
             Model {
                 // xmlns: None,
                 unit: None, //ToDo: Set the default value when unit is not supplied.
-                requiredextensions: None,
-                recommendedextensions: None,
+                requiredextensions: ThreemfExtensions::default(),
+                recommendedextensions: ThreemfExtensions::default(),
                 metadata: vec![Metadata {
                     name: "Trial Metadata".to_owned(),
                     preserve: None,
@@ -1425,8 +1617,8 @@ mod speed_optimized_read_tests {
             Model {
                 // xmlns: None,
                 unit: Some(Unit::Millimeter),
-                requiredextensions: None,
-                recommendedextensions: None,
+                requiredextensions: ThreemfExtensions::default(),
+                recommendedextensions: ThreemfExtensions::default(),
                 metadata: vec![Metadata {
                     name: "Trial Metadata".to_owned(),
                     preserve: None,
@@ -1534,8 +1726,8 @@ mod speed_optimized_read_tests {
             model,
             Model {
                 unit: Some(Unit::Millimeter),
-                requiredextensions: None,
-                recommendedextensions: None,
+                requiredextensions: ThreemfExtensions::default(),
+                recommendedextensions: ThreemfExtensions::default(),
                 metadata: vec![],
                 resources: Resources {
                     basematerials: vec![],

--- a/threemf2/src/core/object.rs
+++ b/threemf2/src/core/object.rs
@@ -31,7 +31,7 @@ use crate::{
 #[cfg_attr(feature = "memory-optimized-read", derive(FromXml))]
 #[cfg_attr(feature = "write", derive(ToXml))]
 #[derive(PartialEq, Debug, Clone)]
-#[cfg_attr(any(feature="write", feature="memory-optimized-read"), xml(ns(CORE_NS, p=PROD_NS, bo=BOOLEAN_NS, s=SLICE_NS), rename="object"))]
+#[cfg_attr(any(feature="write", feature="memory-optimized-read"), xml(ns(CORE_NS, p=PROD_NS, bo=BOOLEAN_NS, s=SLICE_NS), rename="object", force_prefix))]
 pub struct Object {
     /// A unique identifier for this object
     #[cfg_attr(

--- a/threemf2/src/core/resources.rs
+++ b/threemf2/src/core/resources.rs
@@ -253,12 +253,13 @@ mod write_tests {
     #[test]
     pub fn toxml_resources_with_slicestack_test() {
         let xml_string = format!(
-            r##"<resources xmlns="{}" xmlns:{}="{}" xmlns:{}="{}"><{}:slicestack id="236" zbottom="0.5"><sliceref slicestackid="154" slicepath="/2D/model.model" /></{}:slicestack></resources>"##,
+            r##"<resources xmlns="{}" xmlns:{}="{}" xmlns:{}="{}"><{}:slicestack id="236" zbottom="0.5"><{}:sliceref slicestackid="154" slicepath="/2D/model.model" /></{}:slicestack></resources>"##,
             CORE_NS,
             MATERIAL_PREFIX,
             MATERIAL_NS,
             SLICE_PREFIX,
             SLICE_NS,
+            SLICE_PREFIX,
             SLICE_PREFIX,
             SLICE_PREFIX,
         );
@@ -330,12 +331,14 @@ mod write_tests {
     #[test]
     pub fn toxml_resources_with_colorgroup_test() {
         let xml_string = format!(
-            r##"<resources xmlns="{}" xmlns:{}="{}" xmlns:{}="{}"><{}:colorgroup id="1"><color color="#FF0000FF" /><color color="#00FF00FF" /></{}:colorgroup></resources>"##,
+            r##"<resources xmlns="{}" xmlns:{}="{}" xmlns:{}="{}"><{}:colorgroup id="1"><{}:color color="#FF0000FF" /><{}:color color="#00FF00FF" /></{}:colorgroup></resources>"##,
             CORE_NS,
             MATERIAL_PREFIX,
             MATERIAL_NS,
             SLICE_PREFIX,
             SLICE_NS,
+            MATERIAL_PREFIX,
+            MATERIAL_PREFIX,
             MATERIAL_PREFIX,
             MATERIAL_PREFIX
         );
@@ -370,12 +373,14 @@ mod write_tests {
     #[test]
     pub fn toxml_resources_with_texture2dgroup_test() {
         let xml_string = format!(
-            r##"<resources xmlns="{}" xmlns:{}="{}" xmlns:{}="{}"><{}:texture2dgroup id="2" texid="1"><tex2coord u="0" v="0" /><tex2coord u="1" v="1" /></{}:texture2dgroup></resources>"##,
+            r##"<resources xmlns="{}" xmlns:{}="{}" xmlns:{}="{}"><{}:texture2dgroup id="2" texid="1"><{}:tex2coord u="0" v="0" /><{}:tex2coord u="1" v="1" /></{}:texture2dgroup></resources>"##,
             CORE_NS,
             MATERIAL_PREFIX,
             MATERIAL_NS,
             SLICE_PREFIX,
             SLICE_NS,
+            MATERIAL_PREFIX,
+            MATERIAL_PREFIX,
             MATERIAL_PREFIX,
             MATERIAL_PREFIX
         );
@@ -413,12 +418,14 @@ mod write_tests {
     #[test]
     pub fn toxml_resources_with_compositematerials_test() {
         let xml_string = format!(
-            r##"<resources xmlns="{}" xmlns:{}="{}" xmlns:{}="{}"><{}:compositematerials id="1" matid="10" matindices="0 1"><composite values="1 0" /><composite values="0.5 0.5" /></{}:compositematerials></resources>"##,
+            r##"<resources xmlns="{}" xmlns:{}="{}" xmlns:{}="{}"><{}:compositematerials id="1" matid="10" matindices="0 1"><{}:composite values="1 0" /><{}:composite values="0.5 0.5" /></{}:compositematerials></resources>"##,
             CORE_NS,
             MATERIAL_PREFIX,
             MATERIAL_NS,
             SLICE_PREFIX,
             SLICE_NS,
+            MATERIAL_PREFIX,
+            MATERIAL_PREFIX,
             MATERIAL_PREFIX,
             MATERIAL_PREFIX
         );
@@ -455,12 +462,14 @@ mod write_tests {
     #[test]
     pub fn toxml_resources_with_multiproperties_test() {
         let xml_string = format!(
-            r##"<resources xmlns="{}" xmlns:{}="{}" xmlns:{}="{}"><{}:multiproperties id="1" pids="10 20 30" blendmethods="mix multiply"><multi pindices="0 0 0" /><multi pindices="1 2 3" /></{}:multiproperties></resources>"##,
+            r##"<resources xmlns="{}" xmlns:{}="{}" xmlns:{}="{}"><{}:multiproperties id="1" pids="10 20 30" blendmethods="mix multiply"><{}:multi pindices="0 0 0" /><{}:multi pindices="1 2 3" /></{}:multiproperties></resources>"##,
             CORE_NS,
             MATERIAL_PREFIX,
             MATERIAL_NS,
             SLICE_PREFIX,
             SLICE_NS,
+            MATERIAL_PREFIX,
+            MATERIAL_PREFIX,
             MATERIAL_PREFIX,
             MATERIAL_PREFIX
         );
@@ -528,12 +537,13 @@ mod write_tests {
     #[test]
     pub fn toxml_resources_with_multiple_material_types_test() {
         let xml_string = format!(
-            r##"<resources xmlns="{}" xmlns:{}="{}" xmlns:{}="{}"><{}:colorgroup id="1"><color color="#FF0000FF" /></{}:colorgroup><{}:texture2d id="2" path="/3D/texture.png" contenttype="image/png" /></resources>"##,
+            r##"<resources xmlns="{}" xmlns:{}="{}" xmlns:{}="{}"><{}:colorgroup id="1"><{}:color color="#FF0000FF" /></{}:colorgroup><{}:texture2d id="2" path="/3D/texture.png" contenttype="image/png" /></resources>"##,
             CORE_NS,
             MATERIAL_PREFIX,
             MATERIAL_NS,
             SLICE_PREFIX,
             SLICE_NS,
+            MATERIAL_PREFIX,
             MATERIAL_PREFIX,
             MATERIAL_PREFIX,
             MATERIAL_PREFIX

--- a/threemf2/src/core/slice.rs
+++ b/threemf2/src/core/slice.rs
@@ -116,7 +116,7 @@ impl From<String> for MeshResolution {
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(SLICE_NS), rename = "slicestack")
+    xml(ns(SLICE_NS), rename = "slicestack", force_prefix)
 )]
 pub struct SliceStack {
     /// Unique identifier for this slice stack within the model part.
@@ -158,7 +158,7 @@ impl SliceStack {
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(SLICE_NS), rename = "sliceref")
+    xml(ns(SLICE_NS), rename = "sliceref", force_prefix)
 )]
 pub struct SliceRef {
     /// Identifies the SliceStack in the referenced file.
@@ -187,7 +187,7 @@ pub struct SliceRef {
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(SLICE_NS), rename = "slice")
+    xml(ns(SLICE_NS), rename = "slice", force_prefix)
 )]
 pub struct Slice {
     /// Z-position of the top of this slice relative to the build platform.
@@ -211,7 +211,10 @@ pub struct Slice {
 #[cfg_attr(feature = "speed-optimized-read", derive(Deserialize))]
 #[cfg_attr(feature = "write", derive(ToXml))]
 #[derive(Debug, PartialEq, Clone)]
-#[cfg_attr(feature = "write", xml(ns(SLICE_NS), rename = "vertices"))]
+#[cfg_attr(
+    feature = "write",
+    xml(ns(SLICE_NS), rename = "vertices", force_prefix)
+)]
 pub struct Vertices {
     #[cfg_attr(feature = "speed-optimized-read", serde(default))]
     pub vertex: Vec<Vertex>,
@@ -274,7 +277,7 @@ impl<'xml> FromXml<'xml> for Vertices {
 #[cfg_attr(feature = "speed-optimized-read", derive(Deserialize))]
 #[cfg_attr(feature = "write", derive(ToXml))]
 #[derive(Debug, PartialEq, Clone)]
-#[cfg_attr(feature = "write", xml(ns(SLICE_NS), rename = "vertex"))]
+#[cfg_attr(feature = "write", xml(ns(SLICE_NS), rename = "vertex", force_prefix))]
 pub struct Vertex {
     #[cfg_attr(feature = "write", xml(attribute))]
     pub x: Double,
@@ -347,7 +350,7 @@ impl<'xml> FromXml<'xml> for Vertex {
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(SLICE_NS), rename = "polygon")
+    xml(ns(SLICE_NS), rename = "polygon", force_prefix)
 )]
 pub struct Polygon {
     /// Index of the first vertex of the first segment.
@@ -370,7 +373,7 @@ pub struct Polygon {
 #[cfg_attr(feature = "speed-optimized-read", derive(Deserialize))]
 #[cfg_attr(feature = "write", derive(ToXml))]
 #[derive(Debug, PartialEq, Clone)]
-#[cfg_attr(feature = "write", xml(ns(SLICE_NS), rename = "segment"))]
+#[cfg_attr(feature = "write", xml(ns(SLICE_NS), rename = "segment", force_prefix))]
 pub struct Segment {
     /// Index of the second vertex of this segment.
     #[cfg_attr(feature = "write", xml(attribute))]

--- a/threemf2/src/core/transform.rs
+++ b/threemf2/src/core/transform.rs
@@ -40,7 +40,8 @@ impl ToXml for Transform {
     ) -> Result<(), Error> {
         let prefix = match field {
             Some(id) => {
-                let prefix = serializer.write_start(id.name, id.ns)?;
+                let prefix =
+                    serializer.write_start(id.name, id.ns, None::<instant_xml::ser::Context<0>>)?;
                 serializer.end_start()?;
                 Some((prefix, id.name))
             }
@@ -55,8 +56,8 @@ impl ToXml for Transform {
             .join(" ");
         serializer.write_str(&transform_str)?;
 
-        if let Some((prefix, name)) = prefix {
-            serializer.write_close(prefix, name)?;
+        if let Some((prefix, _)) = prefix {
+            serializer.write_close(prefix)?;
         }
 
         Ok(())
@@ -86,7 +87,7 @@ impl<'xml> FromXml<'xml> for Transform {
             None => return Err(Error::MissingValue("No transform string found")),
         };
 
-        let result = Transform::from(value.into_owned());
+        let result = Transform::from(value.as_ref());
         *into = Some(result);
         Ok(())
     }
@@ -96,18 +97,38 @@ impl<'xml> FromXml<'xml> for Transform {
     const KIND: Kind = Kind::Scalar;
 }
 
-#[cfg(any(feature = "memory-optimized-read", feature = "speed-optimized-read"))]
+// #[cfg(any(feature = "memory-optimized-read", feature = "speed-optimized-read"))]
 impl From<String> for Transform {
     fn from(value: String) -> Self {
-        let values = value
-            .split(" ")
-            .map(|v| lexical_core::parse(v.as_bytes()).unwrap_or_default())
-            .collect::<Vec<f64>>();
-        //ToDo: Consider parallelizing this
-
-        // write now it can always panic something to improve in the future
-        Self(values.try_into().unwrap())
+        Self(parse_transform_matrix(&value))
     }
+}
+
+impl From<&str> for Transform {
+    fn from(value: &str) -> Self {
+        Self(parse_transform_matrix(value))
+    }
+}
+
+// ToDo: Remove panics
+fn parse_transform_matrix(input: &str) -> [f64; 12] {
+    let mut out = [0.0f64; MATRIX_SIZE];
+    let mut i = 0usize;
+
+    for token in input.split_whitespace() {
+        if i >= MATRIX_SIZE {
+            panic!("Transform values does not contain enough values, expected: {MATRIX_SIZE}")
+        }
+        let value = lexical_core::parse::<f64>(token.as_bytes()).unwrap_or_default();
+        out[i] = value;
+        i += 1;
+    }
+
+    if i != MATRIX_SIZE {
+        panic!("Transform contains more values than expected, expected: {MATRIX_SIZE}")
+    }
+
+    out
 }
 
 impl Index<usize> for Transform {

--- a/threemf2/src/core/transform.rs
+++ b/threemf2/src/core/transform.rs
@@ -43,7 +43,7 @@ impl ToXml for Transform {
                 let prefix =
                     serializer.write_start(id.name, id.ns, None::<instant_xml::ser::Context<0>>)?;
                 serializer.end_start()?;
-                Some((prefix, id.name))
+                Some(prefix)
             }
             None => None,
         };
@@ -56,7 +56,7 @@ impl ToXml for Transform {
             .join(" ");
         serializer.write_str(&transform_str)?;
 
-        if let Some((prefix, _)) = prefix {
+        if let Some(prefix) = prefix {
             serializer.write_close(prefix)?;
         }
 
@@ -97,7 +97,6 @@ impl<'xml> FromXml<'xml> for Transform {
     const KIND: Kind = Kind::Scalar;
 }
 
-// #[cfg(any(feature = "memory-optimized-read", feature = "speed-optimized-read"))]
 impl From<String> for Transform {
     fn from(value: String) -> Self {
         Self(parse_transform_matrix(&value))

--- a/threemf2/src/core/triangle_set.rs
+++ b/threemf2/src/core/triangle_set.rs
@@ -32,19 +32,23 @@ impl ToXml for TriangleSets {
     ) -> Result<(), Error> {
         let prefix = match field {
             Some(id) => {
-                let prefix = serializer.write_start(id.name, id.ns)?;
+                let prefix =
+                    serializer.write_start(id.name, id.ns, None::<instant_xml::ser::Context<0>>)?;
                 serializer.end_start()?;
                 Some((prefix, id.name))
             }
             None => {
-                let _ = serializer.write_start("trianglesets", CORE_TRIANGLESET_NS)?;
-                serializer.push(instant_xml::ser::Context {
-                    default_ns: CORE_TRIANGLESET_NS,
-                    prefixes: [],
-                })?;
+                let mut cx = instant_xml::ser::Context::default();
+                cx.default_ns = CORE_TRIANGLESET_NS;
+                let prefix =
+                    serializer.write_start("trianglesets", CORE_TRIANGLESET_NS, Some(cx))?;
+                // serializer.push(instant_xml::ser::Context {
+                //     default_ns: CORE_TRIANGLESET_NS,
+                //     prefixes: [],
+                // })?;
 
                 serializer.end_start()?;
-                Some((None, "trianglesets"))
+                Some((prefix, "trianglesets"))
             }
         };
 
@@ -58,8 +62,8 @@ impl ToXml for TriangleSets {
             )?;
         }
 
-        if let Some((prefix, name)) = prefix {
-            serializer.write_close(prefix, name)?;
+        if let Some((prefix, _)) = prefix {
+            serializer.write_close(prefix)?;
         }
 
         Ok(())
@@ -73,7 +77,7 @@ impl ToXml for TriangleSets {
 #[cfg_attr(feature = "memory-optimized-read", derive(FromXml))]
 #[cfg_attr(
     feature = "memory-optimized-read",
-    xml(ns(CORE_TRIANGLESET_NS), rename = "triangleset")
+    xml(ns(CORE_TRIANGLESET_NS), rename = "triangleset", force_prefix)
 )]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TriangleSet {
@@ -104,7 +108,8 @@ impl ToXml for TriangleSet {
     ) -> Result<(), Error> {
         let prefix = match field {
             Some(id) => {
-                let prefix = serializer.write_start(id.name, id.ns)?;
+                let prefix =
+                    serializer.write_start(id.name, id.ns, None::<instant_xml::ser::Context<0>>)?;
                 Some((prefix, id.name))
             }
             None => None,
@@ -130,8 +135,8 @@ impl ToXml for TriangleSet {
             triangle_refrange.serialize(field, serializer)?;
         }
 
-        if let Some((prefix, name)) = prefix {
-            serializer.write_close(prefix, name)?;
+        if let Some((prefix, _)) = prefix {
+            serializer.write_close(prefix)?;
         }
 
         Ok(())
@@ -145,7 +150,7 @@ impl ToXml for TriangleSet {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(CORE_TRIANGLESET_NS), rename = "ref")
+    xml(ns(CORE_TRIANGLESET_NS), rename = "ref", force_prefix)
 )]
 pub struct TriangleRef {
     #[cfg_attr(
@@ -162,7 +167,7 @@ pub struct TriangleRef {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     any(feature = "write", feature = "memory-optimized-read"),
-    xml(ns(CORE_TRIANGLESET_NS), rename = "refrange")
+    xml(ns(CORE_TRIANGLESET_NS), rename = "refrange", force_prefix)
 )]
 pub struct TriangleRefRange {
     /// The start index of the range.

--- a/threemf2/src/core/triangle_set.rs
+++ b/threemf2/src/core/triangle_set.rs
@@ -35,20 +35,15 @@ impl ToXml for TriangleSets {
                 let prefix =
                     serializer.write_start(id.name, id.ns, None::<instant_xml::ser::Context<0>>)?;
                 serializer.end_start()?;
-                Some((prefix, id.name))
+                Some(prefix)
             }
             None => {
                 let mut cx = instant_xml::ser::Context::default();
                 cx.default_ns = CORE_TRIANGLESET_NS;
                 let prefix =
                     serializer.write_start("trianglesets", CORE_TRIANGLESET_NS, Some(cx))?;
-                // serializer.push(instant_xml::ser::Context {
-                //     default_ns: CORE_TRIANGLESET_NS,
-                //     prefixes: [],
-                // })?;
-
                 serializer.end_start()?;
-                Some((prefix, "trianglesets"))
+                Some(prefix)
             }
         };
 
@@ -62,7 +57,7 @@ impl ToXml for TriangleSets {
             )?;
         }
 
-        if let Some((prefix, _)) = prefix {
+        if let Some(prefix) = prefix {
             serializer.write_close(prefix)?;
         }
 

--- a/threemf2/src/io/mod.rs
+++ b/threemf2/src/io/mod.rs
@@ -5,14 +5,13 @@ mod error;
 pub use error::Error;
 
 mod utils;
-pub use utils::parse_xmlns_attributes;
 
 pub mod thumbnail_handle;
 
 pub mod validator;
 mod validator_rules;
 
-/// Represents an XML namespace declaration with its prefix and URI
+/// Represents a generic XML namespace declaration with its prefix and URI
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct XmlNamespace {
     /// The namespace prefix (None for default namespace)
@@ -21,14 +20,6 @@ pub struct XmlNamespace {
     pub uri: String,
 }
 
-/// Stores namespace information for a specific model file
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ModelNamespaces {
-    /// Path to the model file
-    pub path: String,
-    /// List of namespaces declared in that model
-    pub namespaces: Vec<XmlNamespace>,
-}
 #[cfg(any(
     feature = "io-memory-optimized-read",
     feature = "io-speed-optimized-read"
@@ -71,8 +62,3 @@ mod threemf_package_lazy_reader;
     )
 ))]
 pub use threemf_package_lazy_reader::{CachePolicy, ThreemfPackageLazyReader};
-
-#[cfg(feature = "io-write")]
-mod builder;
-#[cfg(feature = "io-write")]
-pub use builder::*;

--- a/threemf2/src/io/query.rs
+++ b/threemf2/src/io/query.rs
@@ -2897,7 +2897,7 @@ pub fn get_texture_for_group<'a>(
 #[cfg(feature = "io-memory-optimized-read")]
 #[cfg(test)]
 mod tests {
-    use crate::core::material::TextureContentType;
+    use crate::core::{material::TextureContentType, model::ThreemfExtensions};
 
     use super::*;
 
@@ -3434,8 +3434,8 @@ mod tests {
         // Create an empty model
         let model = crate::core::model::Model {
             unit: None,
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: crate::core::resources::Resources {
                 object: vec![],
@@ -3510,8 +3510,8 @@ mod tests {
         // Create a model with no material resources
         let model = crate::core::model::Model {
             unit: None,
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: vec![],
             resources: crate::core::resources::Resources {
                 object: vec![],

--- a/threemf2/src/io/threemf_package.rs
+++ b/threemf2/src/io/threemf_package.rs
@@ -10,10 +10,8 @@ use crate::threemf_namespaces::ThreemfNamespace;
 use crate::{
     core::model::Model,
     io::{
-        XmlNamespace,
         content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
         error::Error,
-        parse_xmlns_attributes,
         relationship::{Relationship, RelationshipType, Relationships},
         thumbnail_handle::ThumbnailHandle,
         utils,
@@ -64,8 +62,6 @@ pub struct ThreemfPackage {
     /// The extensions defined in the [ContentTypes.xml]
     ///  file should match the extensions of the parts in the package.
     pub content_types: ContentTypes,
-
-    namespaces: HashMap<String, Vec<XmlNamespace>>,
 }
 
 impl ThreemfPackage {
@@ -84,27 +80,6 @@ impl ThreemfPackage {
             unknown_parts,
             relationships,
             content_types,
-            namespaces: HashMap::new(),
-        }
-    }
-
-    pub(crate) fn new_with_namespaces_map(
-        root: Model,
-        sub_models: HashMap<String, Model>,
-        thumbnails: HashMap<String, ThumbnailHandle>,
-        unknown_parts: HashMap<String, Vec<u8>>,
-        relationships: HashMap<String, Relationships>,
-        content_types: ContentTypes,
-        namespaces: HashMap<String, Vec<XmlNamespace>>,
-    ) -> Self {
-        Self {
-            root,
-            sub_models,
-            thumbnails,
-            unknown_parts,
-            relationships,
-            content_types,
-            namespaces,
         }
     }
 }
@@ -211,7 +186,7 @@ impl ThreemfPackage {
             let tag_end = model_pos + end_pos + 1;
             let tag_content = &xml[model_pos..tag_end];
 
-            let xmlns_attrs = parse_xmlns_attributes(tag_content);
+            let xmlns_attrs = utils::parse_xmlns_attributes(tag_content);
 
             // Parse all attributes (simple approach: split by spaces)
             let mut all_attrs = Vec::new();
@@ -366,14 +341,24 @@ impl ThreemfPackage {
 
     //only exists in the loading flow and not on the writing flow
     //if a path is not set then its the root model
-    pub fn get_namespaces_on_model(&self, model_path: Option<&str>) -> Option<Vec<XmlNamespace>> {
-        let path = model_path.unwrap_or("root model");
+    pub fn get_namespaces_on_model(
+        &self,
+        model_path: Option<&str>,
+    ) -> Option<Vec<ThreemfNamespace>> {
+        // let path = model_path.unwrap_or("root model");
 
-        if self.namespaces.contains_key(path) {
-            let namespaces = self.namespaces.get(path);
-            namespaces.cloned()
-        } else {
-            None
+        // if self.namespaces.contains_key(path) {
+        //     let namespaces = self.namespaces.get(path);
+        //     namespaces.cloned()
+        // } else {
+        //     None
+        // }
+        match model_path {
+            Some(sub_model_path) => self
+                .sub_models
+                .get(sub_model_path)
+                .map(|sub_model| sub_model.used_namespaces()),
+            None => Some(self.root.used_namespaces()),
         }
     }
 }
@@ -400,13 +385,13 @@ mod processor {
     use crate::{
         core::model::Model,
         io::{
-            ThreemfPackage, XmlNamespace,
+            ThreemfPackage,
             content_types::ContentTypes,
             error::Error,
             relationship::{RelationshipType, Relationships},
             thumbnail_handle::{ImageFormat, ThumbnailHandle},
             utils,
-            zip_utils::XmlDeserializer,
+            zip_utils::{self, XmlDeserializer},
         },
     };
 
@@ -422,7 +407,7 @@ mod processor {
         unknown_parts: HashMap<String, Vec<u8>>,
         relationships: HashMap<String, Relationships>,
         content_types: ContentTypes,
-        namespaces_map: HashMap<String, Vec<XmlNamespace>>,
+        // namespaces_map: HashMap<String, Vec<XmlNamespace>>,
     }
 
     impl ThreemfPackageProcessor {
@@ -437,19 +422,18 @@ mod processor {
                 unknown_parts: HashMap::new(),
                 relationships,
                 content_types,
-                namespaces_map: HashMap::new(),
+                // namespaces_map: HashMap::new(),
             }
         }
 
         pub(crate) fn into_threemf_package(self) -> ThreemfPackage {
-            ThreemfPackage::new_with_namespaces_map(
+            ThreemfPackage::new(
                 self.root.expect("Root model should be set"),
                 self.sub_models,
                 self.thumbnails,
                 self.unknown_parts,
                 self.relationships,
                 self.content_types,
-                self.namespaces_map,
             )
         }
 
@@ -475,7 +459,8 @@ mod processor {
 
                             match rel.relationship_type {
                                 RelationshipType::Thumbnail => {
-                                    let mut bytes = Vec::new();
+                                    let size = file.size() as usize;
+                                    let mut bytes = Vec::with_capacity(size);
                                     file.read_to_end(&mut bytes)?;
 
                                     let format = {
@@ -498,21 +483,18 @@ mod processor {
                                 }
                                 RelationshipType::Model => {
                                     let is_root = rel.target == root_model_path;
-
-                                    let (model, namespaces) =
-                                        deserializer.deserialize_model(&mut file)?;
+                                    let model_string =
+                                        zip_utils::read_zipfile_to_string(&mut file)?;
+                                    let model = deserializer.deserialize_model(&model_string)?;
                                     if is_root {
                                         self.root = Some(model);
-                                        self.namespaces_map
-                                            .insert("root model".to_string(), namespaces);
                                     } else {
                                         self.sub_models.insert(rel.target.to_string(), model);
-                                        self.namespaces_map
-                                            .insert(rel.target.to_string(), namespaces);
                                     }
                                 }
                                 RelationshipType::Unknown(_) => {
-                                    let mut bytes = Vec::new();
+                                    let size = file.size() as usize;
+                                    let mut bytes = Vec::with_capacity(size);
                                     file.read_to_end(&mut bytes)?;
 
                                     self.unknown_parts.insert(rel.target.to_string(), bytes);
@@ -655,15 +637,17 @@ mod tests {
     #[test]
     pub fn write_root_model_test() {
         let bytes = {
-            use crate::core::{OptionalResourceId, OptionalResourceIndex};
+            use crate::core::{
+                OptionalResourceId, OptionalResourceIndex, model::ThreemfExtensions,
+            };
 
             let bytes = Vec::<u8>::new();
             let mut writer = Cursor::new(bytes);
             let threemf = ThreemfPackage::new(
                 Model {
                     unit: Some(model::Unit::Centimeter),
-                    requiredextensions: None,
-                    recommendedextensions: None,
+                    requiredextensions: ThreemfExtensions::default(),
+                    recommendedextensions: ThreemfExtensions::default(),
                     metadata: vec![],
                     resources: Resources {
                         object: vec![Object {
@@ -733,6 +717,8 @@ mod tests {
     #[cfg(all(feature = "io-memory-optimized-read", feature = "io-write"))]
     #[test]
     pub fn io_unknown_content_test() {
+        use crate::core::model::ThreemfExtensions;
+
         let test_file_bytes = include_bytes!("../../tests/data/test.txt");
         let mut writer = Cursor::new(Vec::<u8>::new());
         let unknown_target = "/Metadata/test.txt";
@@ -740,8 +726,8 @@ mod tests {
         let package = ThreemfPackage::new(
             Model {
                 unit: Some(model::Unit::Millimeter),
-                requiredextensions: None,
-                recommendedextensions: None,
+                requiredextensions: ThreemfExtensions::default(),
+                recommendedextensions: ThreemfExtensions::default(),
                 metadata: vec![],
                 resources: Resources {
                     object: vec![],
@@ -820,7 +806,10 @@ mod tests {
     #[cfg(all(feature = "io-memory-optimized-read", feature = "io-write"))]
     #[test]
     pub fn io_thumbnail_content_test() {
-        use crate::io::thumbnail_handle::{ImageFormat, ThumbnailHandle};
+        use crate::{
+            core::model::ThreemfExtensions,
+            io::thumbnail_handle::{ImageFormat, ThumbnailHandle},
+        };
 
         let test_file_bytes = include_bytes!("../../tests/data/test_thumbnail.png");
         let thumbnail_rep = ThumbnailHandle {
@@ -834,8 +823,8 @@ mod tests {
         let package = ThreemfPackage::new(
             Model {
                 unit: Some(model::Unit::Millimeter),
-                requiredextensions: None,
-                recommendedextensions: None,
+                requiredextensions: ThreemfExtensions::default(),
+                recommendedextensions: ThreemfExtensions::default(),
                 metadata: vec![],
                 resources: Resources {
                     object: vec![],
@@ -922,9 +911,19 @@ mod tests {
         let result = ThreemfPackage::from_reader_with_memory_optimized_deserializer(reader, true);
         match result {
             Ok(threemf) => {
+                use crate::threemf_namespaces::ThreemfNamespace;
+
                 let root_namespaces = threemf.get_namespaces_on_model(None).unwrap();
-                //println!("Namespaces: {:?}", root_namespaces);
-                assert_eq!(root_namespaces.len(), 5);
+                assert_eq!(
+                    root_namespaces,
+                    [
+                        ThreemfNamespace::Core,
+                        ThreemfNamespace::Prod,
+                        ThreemfNamespace::BeamLattice,
+                        ThreemfNamespace::Material,
+                        ThreemfNamespace::Displacement
+                    ]
+                );
             }
             Err(err) => panic!("{:?}", err),
         }
@@ -940,11 +939,20 @@ mod tests {
         let result = ThreemfPackage::from_reader_with_memory_optimized_deserializer(reader, true);
         match result {
             Ok(threemf) => {
+                use crate::threemf_namespaces::ThreemfNamespace;
+
                 let root_namespaces = threemf
                     .get_namespaces_on_model(Some("/3D/Objects/Object(3).model"))
                     .unwrap();
-                //println!("Namespaces: {:?}", root_namespaces);
-                assert_eq!(root_namespaces.len(), 4);
+                assert_eq!(
+                    root_namespaces,
+                    [
+                        ThreemfNamespace::Core,
+                        ThreemfNamespace::Prod,
+                        ThreemfNamespace::BeamLattice,
+                        ThreemfNamespace::Material
+                    ]
+                );
             }
             Err(err) => panic!("{:?}", err),
         }
@@ -962,25 +970,17 @@ mod tests {
         let result = ThreemfPackage::from_reader_with_memory_optimized_deserializer(reader, true);
         match result {
             Ok(threemf) => {
+                use crate::threemf_namespaces::ThreemfNamespace;
+
                 let root_namespaces = threemf.get_namespaces_on_model(None).unwrap();
 
                 // Verify that Boolean Operations namespace is tracked
-                let has_boolean_ns = root_namespaces.iter().any(|ns| ns.uri == BOOLEAN_NS);
                 assert!(
-                    has_boolean_ns,
+                    root_namespaces
+                        .iter()
+                        .any(|ns| matches!(ns, ThreemfNamespace::Boolean)),
                     "Boolean Operations namespace ({})",
                     BOOLEAN_NS
-                );
-
-                // Also verify the namespace prefix
-                let boolean_ns = root_namespaces
-                    .iter()
-                    .find(|ns| ns.uri == BOOLEAN_NS)
-                    .expect("Boolean namespace should be present");
-                assert_eq!(
-                    boolean_ns.prefix.as_deref(),
-                    Some("bo"),
-                    "Boolean namespace should have 'bo' prefix"
                 );
             }
             Err(err) => panic!("{:?}", err),

--- a/threemf2/src/io/threemf_package.rs
+++ b/threemf2/src/io/threemf_package.rs
@@ -339,20 +339,11 @@ impl ThreemfPackage {
         Ok(processor.into_threemf_package())
     }
 
-    //only exists in the loading flow and not on the writing flow
-    //if a path is not set then its the root model
+    //if path is set or not found then its the root model
     pub fn get_namespaces_on_model(
         &self,
         model_path: Option<&str>,
     ) -> Option<Vec<ThreemfNamespace>> {
-        // let path = model_path.unwrap_or("root model");
-
-        // if self.namespaces.contains_key(path) {
-        //     let namespaces = self.namespaces.get(path);
-        //     namespaces.cloned()
-        // } else {
-        //     None
-        // }
         match model_path {
             Some(sub_model_path) => self
                 .sub_models

--- a/threemf2/src/io/threemf_package_lazy_reader.rs
+++ b/threemf2/src/io/threemf_package_lazy_reader.rs
@@ -7,7 +7,7 @@ use zip::ZipArchive;
 
 use crate::core::model::Model;
 use crate::io::thumbnail_handle::{ImageFormat, ThumbnailHandle};
-use crate::io::{XmlNamespace, utils};
+use crate::io::utils;
 use crate::io::{
     content_types::{ContentTypes, DefaultContentTypeEnum},
     error::Error,
@@ -43,10 +43,10 @@ pub struct ThreemfPackageLazyReader<R: Read + Seek> {
     root_model_path: String,
 
     // always cached on first access
-    root_model: OnceCell<(Model, Vec<XmlNamespace>)>,
+    root_model: OnceCell<Model>,
 
     // cached based on cachepolicy
-    sub_models: RefCell<HashMap<String, (Model, Vec<XmlNamespace>)>>,
+    sub_models: RefCell<HashMap<String, Model>>,
     thumbnails: RefCell<HashMap<String, ThumbnailHandle>>,
     unknown_parts: RefCell<HashMap<String, Vec<u8>>>,
 }
@@ -164,14 +164,14 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
             })
     }
 
-    pub fn root_model(&self) -> Result<&(Model, Vec<XmlNamespace>), Error> {
+    pub fn root_model(&self) -> Result<&Model, Error> {
         self.root_model
             .get_or_try_init(|| self.load_model_from_archive(&self.root_model_path))
     }
 
     pub fn with_model<F, T>(&self, path: &str, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&(Model, Vec<XmlNamespace>)) -> T,
+        F: FnOnce(&Model) -> T,
     {
         if path == self.root_model_path {
             let model = self.root_model()?;
@@ -359,10 +359,11 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
         Ok(f(&xml_string))
     }
 
-    fn load_model_from_archive(&self, path: &str) -> Result<(Model, Vec<XmlNamespace>), Error> {
+    fn load_model_from_archive(&self, path: &str) -> Result<Model, Error> {
         let mut archive = self.archive.borrow_mut();
         let mut file = archive.by_name(utils::try_strip_leading_slash(path))?;
-        self.deserializer.deserialize_model(&mut file)
+        let model_string = zip_utils::read_zipfile_to_string(&mut file)?;
+        self.deserializer.deserialize_model(&model_string)
     }
 
     fn load_thumbnail_from_archive(&self, path: &str) -> Result<ThumbnailHandle, Error> {
@@ -454,9 +455,9 @@ mod tests {
         let paths: Vec<_> = package.model_paths().collect();
         assert!(!paths.is_empty());
 
-        let (root_model, root_ns) = package.root_model().unwrap();
+        let root_model = package.root_model().unwrap();
         assert_eq!(root_model.build.item.len(), 2);
-        assert_eq!(root_ns.len(), 3);
+        assert_eq!(root_model.used_namespaces().len(), 3);
     }
 
     #[cfg(feature = "io-memory-optimized-read")]
@@ -477,9 +478,9 @@ mod tests {
         let model_paths: Vec<_> = package.model_paths().collect();
         assert!(model_paths.len() >= 2); // root + at least one sub-model
 
-        let (root_model, root_ns) = package.root_model().unwrap();
+        let root_model = package.root_model().unwrap();
         assert!(!root_model.resources.object.is_empty());
-        assert_eq!(root_ns.len(), 2);
+        assert_eq!(root_model.used_namespaces().len(), 2);
 
         let sub_model_path = "/3D/midway.model";
         let exists = package.with_model(sub_model_path, |_| true);
@@ -529,9 +530,9 @@ mod tests {
 
         assert!(!package.relationships().is_empty());
 
-        let (root_model, root_ns) = package.root_model().unwrap();
+        let root_model = package.root_model().unwrap();
         assert_eq!(root_model.build.item.len(), 2);
-        assert_eq!(root_ns.len(), 3);
+        assert_eq!(root_model.used_namespaces().len(), 3);
     }
 
     #[cfg(feature = "io-memory-optimized-read")]

--- a/threemf2/src/io/validator_rules.rs
+++ b/threemf2/src/io/validator_rules.rs
@@ -314,6 +314,7 @@ mod tests {
     use super::*;
     use crate::core::{
         build::Build,
+        model::ThreemfExtensions,
         object::{Object, ObjectKind},
         resources::{BaseMaterials, Resources},
         types::OptionalResourceId,
@@ -322,8 +323,8 @@ mod tests {
     fn create_test_model(resources: Resources, build: Build) -> Model {
         Model {
             unit: None,
-            requiredextensions: None,
-            recommendedextensions: None,
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
             metadata: Vec::new(),
             resources,
             build,

--- a/threemf2/src/io/zip_utils.rs
+++ b/threemf2/src/io/zip_utils.rs
@@ -1,18 +1,20 @@
 use zip::ZipArchive;
 
-use crate::io::{
-    XmlNamespace,
-    content_types::{ContentTypes, DefaultContentTypeEnum},
-    error::Error,
-    parse_xmlns_attributes,
-    relationship::Relationships,
+use crate::{
+    core::model::ThreemfExtensions,
+    io::{
+        content_types::{ContentTypes, DefaultContentTypeEnum},
+        error::Error,
+        relationship::Relationships,
+    },
+    threemf_namespaces::ThreemfNamespace,
 };
 
 use crate::core::model::Model;
 
-use std::ffi::OsStr;
 use std::io::{Read, Seek};
 use std::path::Path;
+use std::{collections::HashSet, ffi::OsStr};
 
 /// Enum for different XML deserialization strategies
 #[cfg(any(
@@ -28,64 +30,125 @@ pub(crate) enum XmlDeserializer {
 }
 
 impl XmlDeserializer {
-    pub(crate) fn deserialize_content_types<R: Read>(
+    pub(crate) fn deserialize_content_types(
         &self,
-        mut reader: R,
+        xml_string: &str,
     ) -> Result<ContentTypes, Error> {
         match self {
             #[cfg(feature = "io-memory-optimized-read")]
             XmlDeserializer::MemoryOptimized => {
-                let mut xml_string = String::new();
-                reader.read_to_string(&mut xml_string)?;
-                instant_xml::from_str::<ContentTypes>(&xml_string).map_err(Error::from)
+                instant_xml::from_str::<ContentTypes>(xml_string).map_err(Error::from)
             }
             #[cfg(feature = "io-speed-optimized-read")]
             XmlDeserializer::SpeedOptimized => {
-                let mut xml_string = String::new();
-                reader.read_to_string(&mut xml_string)?;
-                serde_roxmltree::from_str::<ContentTypes>(&xml_string).map_err(Error::from)
+                serde_roxmltree::from_str::<ContentTypes>(xml_string).map_err(Error::from)
             }
         }
     }
 
-    pub(crate) fn deserialize_relationships<R: Read>(
+    pub(crate) fn deserialize_relationships(
         &self,
-        mut reader: R,
+        xml_string: &str,
     ) -> Result<Relationships, Error> {
         match self {
             #[cfg(feature = "io-memory-optimized-read")]
             XmlDeserializer::MemoryOptimized => {
-                let mut xml_string = String::new();
-                reader.read_to_string(&mut xml_string)?;
-                instant_xml::from_str::<Relationships>(&xml_string).map_err(Error::from)
+                instant_xml::from_str::<Relationships>(xml_string).map_err(Error::from)
             }
             #[cfg(feature = "io-speed-optimized-read")]
             XmlDeserializer::SpeedOptimized => {
-                let mut xml_string = String::new();
-                reader.read_to_string(&mut xml_string)?;
-                serde_roxmltree::from_str::<Relationships>(&xml_string).map_err(Error::from)
+                serde_roxmltree::from_str::<Relationships>(xml_string).map_err(Error::from)
             }
         }
     }
 
-    pub(crate) fn deserialize_model<R: Read>(
-        &self,
-        reader: &mut R,
-    ) -> Result<(Model, Vec<XmlNamespace>), Error> {
-        let mut xml_string = String::new();
-        reader.read_to_string(&mut xml_string)?;
-
-        let namespaces = parse_xmlns_attributes(&xml_string);
-
+    pub(crate) fn deserialize_model(&self, xml_string: &str) -> Result<Model, Error> {
         let model = match self {
             #[cfg(feature = "io-memory-optimized-read")]
-            XmlDeserializer::MemoryOptimized => instant_xml::from_str::<Model>(&xml_string)?,
+            XmlDeserializer::MemoryOptimized => instant_xml::from_str::<Model>(xml_string)?,
             #[cfg(feature = "io-speed-optimized-read")]
-            XmlDeserializer::SpeedOptimized => serde_roxmltree::from_str::<Model>(&xml_string)?,
+            XmlDeserializer::SpeedOptimized => speed_optimized_read(xml_string),
         };
 
-        Ok((model, namespaces))
+        Ok(model)
     }
+}
+
+fn speed_optimized_read(xml_string: &str) -> Model {
+    use serde_roxmltree::roxmltree::Document;
+
+    let doc = Document::parse(xml_string).unwrap();
+    let mut model = serde_roxmltree::from_doc::<Model>(&doc).unwrap();
+
+    let mut threemf_namespaces = vec![];
+    let namespaces = doc.root().first_child().unwrap().namespaces();
+    for ns in namespaces.clone() {
+        let threemf_ns = ThreemfNamespace::try_from_uri(ns.uri(), ns.name()).unwrap();
+        threemf_namespaces.push(threemf_ns);
+    }
+
+    let mut new_recommended_extensions = HashSet::new();
+    for ns in model.recommendedextensions.get() {
+        match ns {
+            ThreemfNamespace::Unknown { prefix, uri } => {
+                if let Some(ns) = namespaces
+                    .clone()
+                    .find(|ns| ns.name() == Some(prefix.as_str()))
+                {
+                    let threemf_ns = ThreemfNamespace::try_from_uri(ns.uri(), ns.name()).unwrap();
+                    new_recommended_extensions.insert(threemf_ns);
+                } else {
+                    new_recommended_extensions.insert(ThreemfNamespace::Unknown {
+                        prefix: prefix.to_owned(),
+                        uri: uri.to_owned(),
+                    });
+                }
+            }
+            _ => {
+                new_recommended_extensions.insert(ns.clone());
+            }
+        }
+    }
+
+    let mut new_required_extensions = HashSet::new();
+    for ns in model.requiredextensions.get() {
+        match ns {
+            ThreemfNamespace::Unknown { prefix, uri } => {
+                if let Some(ns) = namespaces
+                    .clone()
+                    .find(|ns| ns.name() == Some(prefix.as_str()))
+                {
+                    let threemf_ns = ThreemfNamespace::try_from_uri(ns.uri(), ns.name()).unwrap();
+                    new_required_extensions.insert(threemf_ns);
+                } else {
+                    new_required_extensions.insert(ThreemfNamespace::Unknown {
+                        prefix: prefix.to_owned(),
+                        uri: uri.to_owned(),
+                    });
+                }
+            }
+            _ => {
+                new_required_extensions.insert(ns.clone());
+            }
+        }
+    }
+
+    let recommended_extensions =
+        ThreemfExtensions::new_from_iter(new_recommended_extensions.iter());
+    let required_extensions = ThreemfExtensions::new_from_iter(new_required_extensions.iter());
+
+    model.recommendedextensions = recommended_extensions;
+    model.requiredextensions = required_extensions;
+    model
+}
+
+pub(crate) fn read_zipfile_to_string<R: Read>(
+    file: &mut zip::read::ZipFile<'_, R>,
+) -> Result<String, Error> {
+    let size_hint = file.size() as usize;
+    let mut xml_string = String::with_capacity(size_hint);
+    file.read_to_string(&mut xml_string)?;
+    Ok(xml_string)
 }
 
 pub(crate) fn setup_archive_and_content_types<R: Read + Seek>(
@@ -109,9 +172,8 @@ fn parse_content_types<R: Read + Seek>(
     let content_types_file = zip.by_name("[Content_Types].xml");
     match content_types_file {
         Ok(mut file) => {
-            let mut xml_string = String::new();
-            file.read_to_string(&mut xml_string)?;
-            let content_types = deserializer.deserialize_content_types(xml_string.as_bytes())?;
+            let xml_string = read_zipfile_to_string(&mut file)?;
+            let content_types = deserializer.deserialize_content_types(&xml_string)?;
             Ok((content_types, xml_string))
         }
         Err(err) => Err(Error::Zip(err)),
@@ -158,10 +220,11 @@ pub(crate) fn discover_relationship_files<R: Read + Seek>(
 }
 
 pub(crate) fn relationships_from_zipfile<R: Read>(
-    file: zip::read::ZipFile<'_, R>,
+    mut file: zip::read::ZipFile<'_, R>,
     deserializer: &XmlDeserializer,
 ) -> Result<Relationships, Error> {
-    deserializer.deserialize_relationships(file)
+    let xml_string = read_zipfile_to_string(&mut file)?;
+    deserializer.deserialize_relationships(&xml_string)
 }
 
 pub(crate) fn relationships_from_zip_by_name<R: Read + Seek>(

--- a/threemf2/src/threemf_namespaces.rs
+++ b/threemf2/src/threemf_namespaces.rs
@@ -42,7 +42,7 @@ pub const DISPLACEMENT_NS: &str = "http://schemas.3mf.io/3dmanufacturing/displac
 pub const DISPLACEMENT_PREFIX: &str = "d";
 
 /// Enum representing the different 3MF specifications supported by this library
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ThreemfNamespace {
     /// Core 3MF
     Core,
@@ -70,11 +70,14 @@ pub enum ThreemfNamespace {
 
     /// Displacement extension
     Displacement,
+
+    /// Unknown namespace
+    Unknown { prefix: String, uri: String },
 }
 
 impl ThreemfNamespace {
     /// Returns the namespace Uri
-    pub fn uri(&self) -> &'static str {
+    pub fn uri(&self) -> &str {
         match self {
             Self::Core => CORE_NS,
             Self::Slice => SLICE_NS,
@@ -85,13 +88,14 @@ impl ThreemfNamespace {
             Self::CoreTriangleSet => CORE_TRIANGLESET_NS,
             Self::Material => MATERIAL_NS,
             Self::Displacement => DISPLACEMENT_NS,
+            Self::Unknown { prefix: _, uri } => uri,
         }
     }
 
     /// Returns the default prefix used by this library for this namespace
     /// Note: This is not reflective of prefix that maybe used by other
     /// producers.
-    pub fn prefix(&self) -> Option<&'static str> {
+    pub fn prefix(&self) -> Option<&str> {
         match self {
             Self::Core => None, // default namespace
             Self::Slice => Some(SLICE_PREFIX),
@@ -102,6 +106,49 @@ impl ThreemfNamespace {
             Self::CoreTriangleSet => Some(CORE_TRIANGLESET_PREFIX),
             Self::Material => Some(MATERIAL_PREFIX),
             Self::Displacement => Some(DISPLACEMENT_PREFIX),
+            Self::Unknown { prefix, uri: _ } => Some(prefix),
+        }
+    }
+
+    pub fn try_from_uri(uri: &str, assigned_prefix: Option<&str>) -> Option<Self> {
+        match uri {
+            CORE_NS => Some(Self::Core),
+            CORE_TRIANGLESET_NS => Some(Self::CoreTriangleSet),
+            PROD_NS => Some(Self::Prod),
+            BEAM_LATTICE_NS => Some(Self::BeamLattice),
+            BEAM_LATTICE_BALLS_NS => Some(Self::BeamLatticeBalls),
+            SLICE_NS => Some(Self::Slice),
+            BOOLEAN_NS => Some(Self::Boolean),
+            MATERIAL_NS => Some(Self::Material),
+            DISPLACEMENT_NS => Some(Self::Displacement),
+            _ => assigned_prefix.map(|prefix| Self::Unknown {
+                prefix: prefix.to_owned(),
+                uri: uri.to_owned(),
+            }),
+        }
+    }
+
+    pub fn try_from_prefix(prefix: &str, specified_uri: Option<&str>) -> Option<Self> {
+        match prefix {
+            //CORE_NS => Some(Self::Core),
+            CORE_TRIANGLESET_PREFIX => Some(Self::CoreTriangleSet),
+            PROD_PREFIX => Some(Self::Prod),
+            BEAM_LATTICE_PREFIX => Some(Self::BeamLattice),
+            BEAM_LATTICE_BALLS_PREFIX => Some(Self::BeamLatticeBalls),
+            SLICE_PREFIX => Some(Self::Slice),
+            BOOLEAN_PREFIX => Some(Self::Boolean),
+            MATERIAL_PREFIX => Some(Self::Material),
+            DISPLACEMENT_PREFIX => Some(Self::Displacement),
+            _ => match specified_uri {
+                Some(uri) => Some(Self::Unknown {
+                    prefix: prefix.to_owned(),
+                    uri: uri.to_owned(),
+                }),
+                None => Some(Self::Unknown {
+                    prefix: prefix.to_owned(),
+                    uri: "".to_owned(),
+                }),
+            },
         }
     }
 

--- a/threemf2/tests/beamlattice_io.rs
+++ b/threemf2/tests/beamlattice_io.rs
@@ -56,6 +56,8 @@ mod tests {
 
         match result {
             Ok(package) => {
+                use threemf2::threemf_namespaces::ThreemfNamespace;
+
                 let mesh_obj = get_mesh_objects(&package).collect::<Vec<_>>();
                 assert_eq!(mesh_obj.len(), 5);
 
@@ -66,7 +68,15 @@ mod tests {
                 assert_eq!(beam_lattice_obj, 2);
 
                 let ns = package.get_namespaces_on_model(None).unwrap();
-                assert_eq!(ns.len(), 4);
+                assert_eq!(
+                    ns,
+                    [
+                        ThreemfNamespace::Core,
+                        ThreemfNamespace::Prod,
+                        ThreemfNamespace::BeamLattice,
+                        ThreemfNamespace::Material
+                    ]
+                );
             }
             Err(err) => {
                 panic!("read failed {:?}", err);
@@ -93,11 +103,13 @@ mod tests {
 
         match result {
             Ok(package) => {
+                use threemf2::threemf_namespaces::ThreemfNamespace;
+
                 let mut mesh_objects = 0;
                 let mut beam_lattice_objects = 0;
                 for model_path in package.model_paths() {
                     package
-                        .with_model(model_path, |(model, ns)| {
+                        .with_model(model_path, |model| {
                             use threemf2::io::query;
 
                             mesh_objects = query::get_mesh_objects_from_model(model).count();
@@ -106,7 +118,7 @@ mod tests {
                                 .filter(|mesh_rep| mesh_rep.mesh().beamlattice.is_some())
                                 .count();
 
-                            namespaces.extend_from_slice(ns);
+                            namespaces.extend_from_slice(&model.used_namespaces());
                         })
                         .unwrap();
                 }
@@ -114,7 +126,15 @@ mod tests {
                 assert_eq!(beam_lattice_objects, 2);
 
                 // core, prod, material, beam lattice
-                assert_eq!(namespaces.len(), 4);
+                assert_eq!(
+                    namespaces,
+                    [
+                        ThreemfNamespace::Core,
+                        ThreemfNamespace::Prod,
+                        ThreemfNamespace::BeamLattice,
+                        ThreemfNamespace::Material,
+                    ]
+                );
             }
             Err(err) => {
                 panic!("read failed {:?}", err);
@@ -141,11 +161,13 @@ mod tests {
 
         match result {
             Ok(package) => {
+                use threemf2::threemf_namespaces::ThreemfNamespace;
+
                 let mut mesh_objects = 0;
                 let mut beam_lattice_objects = 0;
                 for model_path in package.model_paths() {
                     package
-                        .with_model(model_path, |(model, ns)| {
+                        .with_model(model_path, |model| {
                             use threemf2::io::query;
 
                             mesh_objects = query::get_mesh_objects_from_model(model).count();
@@ -154,7 +176,7 @@ mod tests {
                                 .filter(|mesh_rep| mesh_rep.mesh().beamlattice.is_some())
                                 .count();
 
-                            namespaces.extend_from_slice(ns);
+                            namespaces.extend_from_slice(&model.used_namespaces());
                         })
                         .unwrap();
                 }
@@ -162,7 +184,15 @@ mod tests {
                 assert_eq!(beam_lattice_objects, 2);
 
                 // core, prod, material, beam lattice
-                assert_eq!(namespaces.len(), 4);
+                assert_eq!(
+                    namespaces,
+                    [
+                        ThreemfNamespace::Core,
+                        ThreemfNamespace::Prod,
+                        ThreemfNamespace::BeamLattice,
+                        ThreemfNamespace::Material
+                    ]
+                );
             }
             Err(err) => {
                 panic!("read failed {:?}", err);

--- a/threemf2/tests/boolean_io.rs
+++ b/threemf2/tests/boolean_io.rs
@@ -26,6 +26,8 @@ mod tests {
         match result {
             Ok(package) => {
                 // Verify we can get mesh objects (base geometry)
+
+                use threemf2::threemf_namespaces::ThreemfNamespace;
                 let mesh_obj = get_mesh_objects(&package).collect::<Vec<_>>();
                 assert_eq!(
                     mesh_obj.len(),
@@ -84,9 +86,7 @@ mod tests {
 
                 // Verify namespaces include boolean operations
                 let ns = package.get_namespaces_on_model(None).unwrap();
-                let has_boolean_ns = ns
-                    .iter()
-                    .any(|n| n.uri == threemf2::threemf_namespaces::BOOLEAN_NS);
+                let has_boolean_ns = ns.iter().any(|n| matches!(n, ThreemfNamespace::Boolean));
                 assert!(
                     has_boolean_ns,
                     "Package should include Boolean Operations namespace"
@@ -115,6 +115,8 @@ mod tests {
         match result {
             Ok(package) => {
                 // Verify we can get mesh objects (base geometry)
+
+                use threemf2::threemf_namespaces::ThreemfNamespace;
                 let mesh_obj = get_mesh_objects(&package).collect::<Vec<_>>();
                 assert_eq!(
                     mesh_obj.len(),
@@ -162,9 +164,7 @@ mod tests {
 
                 // Verify namespaces include boolean operations
                 let ns = package.get_namespaces_on_model(None).unwrap();
-                let has_boolean_ns = ns
-                    .iter()
-                    .any(|n| n.uri == threemf2::threemf_namespaces::BOOLEAN_NS);
+                let has_boolean_ns = ns.iter().any(|n| matches!(n, ThreemfNamespace::Boolean));
                 assert!(
                     has_boolean_ns,
                     "Package should include Boolean Operations namespace"
@@ -202,7 +202,7 @@ mod tests {
 
                 for model_path in package.model_paths() {
                     package
-                        .with_model(model_path, |(model, ns)| {
+                        .with_model(model_path, |model| {
                             use threemf2::io::query;
 
                             mesh_objects = query::get_mesh_objects_from_model(model).count();
@@ -223,7 +223,7 @@ mod tests {
                                 }
                             }
 
-                            namespaces.extend_from_slice(ns);
+                            namespaces.extend_from_slice(&model.used_namespaces());
                         })
                         .unwrap();
                 }
@@ -243,7 +243,7 @@ mod tests {
                 // Verify boolean namespace is present
                 let has_boolean_ns = namespaces
                     .iter()
-                    .any(|n| n.uri == threemf2::threemf_namespaces::BOOLEAN_NS);
+                    .any(|n| n.uri() == threemf2::threemf_namespaces::BOOLEAN_NS);
                 assert!(
                     has_boolean_ns,
                     "Package should include Boolean Operations namespace"
@@ -281,7 +281,7 @@ mod tests {
 
                 for model_path in package.model_paths() {
                     package
-                        .with_model(model_path, |(model, ns)| {
+                        .with_model(model_path, |model| {
                             use threemf2::io::query;
 
                             mesh_objects = query::get_mesh_objects_from_model(model).count();
@@ -302,7 +302,7 @@ mod tests {
                                 }
                             }
 
-                            namespaces.extend_from_slice(ns);
+                            namespaces.extend_from_slice(&model.used_namespaces());
                         })
                         .unwrap();
                 }
@@ -322,7 +322,7 @@ mod tests {
                 // Verify boolean namespace is present
                 let has_boolean_ns = namespaces
                     .iter()
-                    .any(|n| n.uri == threemf2::threemf_namespaces::BOOLEAN_NS);
+                    .any(|n| n.uri() == threemf2::threemf_namespaces::BOOLEAN_NS);
                 assert!(
                     has_boolean_ns,
                     "Package should include Boolean Operations namespace"

--- a/threemf2/tests/core_io.rs
+++ b/threemf2/tests/core_io.rs
@@ -158,7 +158,7 @@ mod tests {
                 for model_path in package.model_paths() {
                     total_model_paths += 1;
                     package
-                        .with_model(model_path, |(model, ns)| {
+                        .with_model(model_path, |model| {
                             //check if some part with some specific id exists
                             if model.resources.object.iter().any(|o| o.id == 1) {
                                 found_object_by_id = true;
@@ -173,7 +173,7 @@ mod tests {
                                 }
                             }
 
-                            namespaces.extend_from_slice(ns);
+                            namespaces.extend_from_slice(&model.used_namespaces());
                         })
                         .unwrap();
                 }
@@ -225,7 +225,7 @@ mod tests {
                 for model_path in package.model_paths() {
                     total_model_paths += 1;
                     package
-                        .with_model(model_path, |(model, ns)| {
+                        .with_model(model_path, |model| {
                             //check if some part with some specific id exists
                             if model.resources.object.iter().any(|o| o.id == 1) {
                                 found_object_by_id = true;
@@ -240,7 +240,7 @@ mod tests {
                                 }
                             }
 
-                            namespaces.extend_from_slice(ns);
+                            namespaces.extend_from_slice(&model.used_namespaces());
                         })
                         .unwrap();
                 }

--- a/threemf2/tests/displacement_io.rs
+++ b/threemf2/tests/displacement_io.rs
@@ -13,6 +13,8 @@ mod tests {
     #[cfg(feature = "io-memory-optimized-read")]
     #[test]
     fn read_displacement_package_memory_optimized() {
+        use threemf2::threemf_namespaces::ThreemfNamespace;
+
         let path =
             PathBuf::from("./tests/data/mgx-core-prod-beamlattice-material-displacement-mesh.3mf");
         let reader = File::open(path).unwrap();
@@ -32,13 +34,15 @@ mod tests {
         assert!(
             namespaces
                 .iter()
-                .any(|ns| ns.uri == threemf2::threemf_namespaces::DISPLACEMENT_NS)
+                .any(|ns| matches!(ns, ThreemfNamespace::Displacement))
         );
     }
 
     #[cfg(feature = "io-speed-optimized-read")]
     #[test]
     fn read_displacement_package_speed_optimized() {
+        use threemf2::threemf_namespaces::ThreemfNamespace;
+
         let path =
             PathBuf::from("./tests/data/mgx-core-prod-beamlattice-material-displacement-mesh.3mf");
         let reader = File::open(path).unwrap();
@@ -58,7 +62,7 @@ mod tests {
         assert!(
             namespaces
                 .iter()
-                .any(|ns| ns.uri == threemf2::threemf_namespaces::DISPLACEMENT_NS)
+                .any(|ns| matches!(ns, ThreemfNamespace::Displacement))
         );
     }
 
@@ -78,7 +82,7 @@ mod tests {
         .unwrap();
 
         package
-            .with_model("/3D/3dmodel.model", |(model, _namespaces)| {
+            .with_model("/3D/3dmodel.model", |model| {
                 assert_eq!(
                     query::get_displacement_mesh_objects_from_model(model).count(),
                     1

--- a/threemf2/tests/material_io.rs
+++ b/threemf2/tests/material_io.rs
@@ -26,6 +26,8 @@ mod tests {
         match result {
             Ok(package) => {
                 // Verify 2 mesh objects
+
+                use threemf2::threemf_namespaces::ThreemfNamespace;
                 let mesh_objects = get_mesh_objects(&package).collect::<Vec<_>>();
                 assert_eq!(mesh_objects.len(), 1);
 
@@ -86,7 +88,7 @@ mod tests {
 
                 // Verify material namespace is present
                 let ns = package.get_namespaces_on_model(None).unwrap();
-                assert!(ns.iter().any(|n| n.uri.contains("material")));
+                assert!(ns.iter().any(|n| matches!(n, ThreemfNamespace::Material)));
             }
             Err(err) => {
                 panic!("read failed {:?}", err);
@@ -109,6 +111,8 @@ mod tests {
         match result {
             Ok(package) => {
                 // Verify 2 mesh objects
+
+                use threemf2::threemf_namespaces::ThreemfNamespace;
                 let mesh_objects = get_mesh_objects(&package).collect::<Vec<_>>();
                 assert_eq!(mesh_objects.len(), 1);
 
@@ -169,7 +173,7 @@ mod tests {
 
                 // Verify material namespace is present
                 let ns = package.get_namespaces_on_model(None).unwrap();
-                assert!(ns.iter().any(|n| n.uri.contains("material")));
+                assert!(ns.iter().any(|n| matches!(n, ThreemfNamespace::Material)));
             }
             Err(err) => {
                 panic!("read failed {:?}", err);

--- a/threemf2/tests/production_io.rs
+++ b/threemf2/tests/production_io.rs
@@ -160,7 +160,7 @@ mod tests {
                 for model_path in package.model_paths() {
                     total_model_paths += 1;
                     package
-                        .with_model(model_path, |(model, ns)| {
+                        .with_model(model_path, |model| {
                             //check if some part with some id exists in a specific sub-model
                             if model_path == "/3D/Objects/Object.model"
                                 && model.resources.object.iter().any(|o| o.id == 1)
@@ -182,7 +182,7 @@ mod tests {
                                 }
                             }
 
-                            namespaces.extend_from_slice(ns);
+                            namespaces.extend_from_slice(&model.used_namespaces());
                         })
                         .unwrap();
                 }
@@ -194,7 +194,7 @@ mod tests {
                 assert!(found_object_by_id);
 
                 // Check build item UUID in root model
-                let (root_model, _) = package.root_model().unwrap();
+                let root_model = package.root_model().unwrap();
                 let can_find_build_item_by_uuid = root_model.build.item.iter().find(|i| {
                     if let Some(uuid) = &i.uuid {
                         uuid == "637f47fa-39e6-4363-b3a9-100329fc5d9c"
@@ -249,7 +249,7 @@ mod tests {
                 for model_path in package.model_paths() {
                     total_model_paths += 1;
                     package
-                        .with_model(model_path, |(model, ns)| {
+                        .with_model(model_path, |model| {
                             //check if some part with some id exists in a specific sub-model
                             if model_path == "/3D/Objects/Object.model"
                                 && model.resources.object.iter().any(|o| o.id == 1)
@@ -271,7 +271,7 @@ mod tests {
                                 }
                             }
 
-                            namespaces.extend_from_slice(ns);
+                            namespaces.extend_from_slice(&model.used_namespaces());
                         })
                         .unwrap();
                 }
@@ -283,7 +283,7 @@ mod tests {
                 assert!(found_object_by_id);
 
                 // Check build item UUID in root model
-                let (root_model, _) = package.root_model().unwrap();
+                let root_model = package.root_model().unwrap();
                 let can_find_build_item_by_uuid = root_model.build.item.iter().find(|i| {
                     if let Some(uuid) = &i.uuid {
                         uuid == "637f47fa-39e6-4363-b3a9-100329fc5d9c"

--- a/threemf2/tests/roundtrip.rs
+++ b/threemf2/tests/roundtrip.rs
@@ -14,7 +14,7 @@ mod tests {
             OptionalResourceId,
             build::{Build, Item},
             mesh::{Mesh, Triangle, Triangles, Vertex, Vertices},
-            model::{Model, Unit},
+            model::{Model, ThreemfExtensions, Unit},
             object::{Object, ObjectKind, ObjectType},
             resources::Resources,
             types::OptionalResourceIndex,
@@ -60,8 +60,8 @@ mod tests {
         let write_package = ThreemfPackage::new(
             Model {
                 unit: Some(Unit::Millimeter),
-                requiredextensions: None,
-                recommendedextensions: None,
+                requiredextensions: ThreemfExtensions::default(),
+                recommendedextensions: ThreemfExtensions::default(),
                 metadata: vec![],
                 resources: Resources {
                     object: vec![Object {
@@ -170,10 +170,10 @@ mod tests {
             assert!(lazy_package.root_model_path().contains("3Dmodel.model"));
 
             // Verify root model content
-            let (root_model, ns) = lazy_package.root_model().unwrap();
+            let root_model = lazy_package.root_model().unwrap();
             assert_eq!(root_model.resources.object.len(), 1);
             assert_eq!(root_model.build.item.len(), 1);
-            assert_eq!(ns.len(), 1);
+            assert_eq!(root_model.used_namespaces().len(), 1);
 
             let obj = &root_model.resources.object[0];
             assert_eq!(obj.id, 1);


### PR DESCRIPTION
- `requiredextensions` and `recommendedextensions` fields in the Model struct now has strongly defined namespaces
- Deserializers smartly evaluates the the namespace prefixes defined in the fields above. 
- Removed the need to specially parse xmlns definitions on Model deserialization, which improves performance by 10%
- Fixed the used_namespaces function to include Core namespace always and fixed processing of some namespace utilities for displacement mesh type. 
- Further performance optimization to avoid allocation churn in Vertices, Triangles and Transform types upon deserialization.  
- Moved builder functions to core: This is an ongoing work to continue in future PR. 
- Moved to instant-xml version 0.7.4 and migrated all writers to use force-prefix flag to always use prefix only. 