### PR TITLE
feat!(io,core): Introduced ThreemfPackageBuilder as public API for creating 3MF packages

### DIFF
--- a/threemf2-tests/tests/third_party_read.rs
+++ b/threemf2-tests/tests/third_party_read.rs
@@ -72,7 +72,7 @@ mod tests {
                 Ok(threemf) => {
                     assert!(!threemf.content_types().defaults.is_empty());
                     assert!(!threemf.relationships().is_empty());
-                    assert_eq!(threemf.root_model_path(), "/3D/3dmodel.model");
+                    assert_eq!(threemf.root_model_path().as_str(), "/3D/3dmodel.model");
                 }
                 Err(err) => {
                     panic!(

--- a/threemf2-xsd-validation/tests/beamlattice_validation.rs
+++ b/threemf2-xsd-validation/tests/beamlattice_validation.rs
@@ -3,7 +3,6 @@
 //! Tests validation of 3MF models with beam lattice structures against
 //! the Beam Lattice extension XSD schemas.
 
-use std::collections::HashMap;
 use std::io::Cursor;
 use threemf2::{
     core::{
@@ -16,11 +15,7 @@ use threemf2::{
         resources::Resources,
         types::OptionalResourceIndex,
     },
-    io::{
-        ThreemfPackage,
-        content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
-        relationship::{Relationship, RelationshipType, Relationships},
-    },
+    io::ThreemfPackageBuilder,
     threemf_namespaces::ThreemfNamespace,
 };
 
@@ -160,75 +155,52 @@ fn validate_simple_beamlattice() {
         beamlattice: Some(beamlattice),
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::BeamLattice]),
-            recommendedextensions: ThreemfExtensions::default(),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![Object {
-                    id: 1,
-                    objecttype: Some(ObjectType::Model),
-                    thumbnail: None,
-                    partnumber: None,
-                    name: Some("Beam Lattice Mesh".into()),
-                    pid: OptionalResourceId::none(),
-                    pindex: OptionalResourceIndex::none(),
-                    uuid: None,
-                    kind: Some(ObjectKind::Mesh(mesh)),
-                    meshresolution: None,
-                    slicestackid: OptionalResourceId::none(),
-                    slicepath: None,
-                }],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![],
-                compositematerials: vec![],
-                texture2dgroup: vec![],
-                multiproperties: vec![],
-                texture2d: Vec::new(),
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
+    let model = Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::BeamLattice]),
+        recommendedextensions: ThreemfExtensions::default(),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![Object {
+                id: 1,
+                objecttype: Some(ObjectType::Model),
+                thumbnail: None,
+                partnumber: None,
+                name: Some("Beam Lattice Mesh".into()),
+                pid: OptionalResourceId::none(),
+                pindex: OptionalResourceIndex::none(),
                 uuid: None,
-                item: vec![Item {
-                    objectid: 1,
-                    transform: None,
-                    partnumber: None,
-                    path: None,
-                    uuid: None,
-                }],
-            },
+                kind: Some(ObjectKind::Mesh(mesh)),
+                meshresolution: None,
+                slicestackid: OptionalResourceId::none(),
+                slicepath: None,
+            }],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![],
+            compositematerials: vec![],
+            texture2dgroup: vec![],
+            multiproperties: vec![],
+            texture2d: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
-                },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
-                },
-            ],
+        build: Build {
+            uuid: None,
+            item: vec![Item {
+                objectid: 1,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: None,
+            }],
         },
-    );
+    };
+
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    let write_package = builder.build().expect("Error building package");
 
     let mut buf = Cursor::new(Vec::new());
     write_package
@@ -330,78 +302,55 @@ fn validate_beamlattice_with_balls() {
         beamlattice: Some(beamlattice),
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::new(&[
-                ThreemfNamespace::BeamLattice,
-                ThreemfNamespace::BeamLatticeBalls,
-            ]),
-            recommendedextensions: ThreemfExtensions::default(),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![Object {
-                    id: 1,
-                    objecttype: Some(ObjectType::Model),
-                    thumbnail: None,
-                    partnumber: None,
-                    name: Some("Beam Lattice with Balls".into()),
-                    pid: OptionalResourceId::none(),
-                    pindex: OptionalResourceIndex::none(),
-                    uuid: None,
-                    kind: Some(ObjectKind::Mesh(mesh)),
-                    meshresolution: None,
-                    slicestackid: OptionalResourceId::none(),
-                    slicepath: None,
-                }],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![],
-                compositematerials: vec![],
-                texture2dgroup: vec![],
-                multiproperties: vec![],
-                texture2d: Vec::new(),
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
+    let model = Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::new(&[
+            ThreemfNamespace::BeamLattice,
+            ThreemfNamespace::BeamLatticeBalls,
+        ]),
+        recommendedextensions: ThreemfExtensions::default(),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![Object {
+                id: 1,
+                objecttype: Some(ObjectType::Model),
+                thumbnail: None,
+                partnumber: None,
+                name: Some("Beam Lattice with Balls".into()),
+                pid: OptionalResourceId::none(),
+                pindex: OptionalResourceIndex::none(),
                 uuid: None,
-                item: vec![Item {
-                    objectid: 1,
-                    transform: None,
-                    partnumber: None,
-                    path: None,
-                    uuid: None,
-                }],
-            },
+                kind: Some(ObjectKind::Mesh(mesh)),
+                meshresolution: None,
+                slicestackid: OptionalResourceId::none(),
+                slicepath: None,
+            }],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![],
+            compositematerials: vec![],
+            texture2dgroup: vec![],
+            multiproperties: vec![],
+            texture2d: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
-                },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
-                },
-            ],
+        build: Build {
+            uuid: None,
+            item: vec![Item {
+                objectid: 1,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: None,
+            }],
         },
-    );
+    };
+
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    let write_package = builder.build().expect("Error building package");
 
     let mut buf = Cursor::new(Vec::new());
     write_package

--- a/threemf2-xsd-validation/tests/booleanoperations_validation.rs
+++ b/threemf2-xsd-validation/tests/booleanoperations_validation.rs
@@ -3,7 +3,6 @@
 //! Tests validation of 3MF models with boolean operations against
 //! the Boolean Operations extension XSD schemas.
 
-use std::collections::HashMap;
 use std::io::Cursor;
 use threemf2::{
     core::{
@@ -17,11 +16,7 @@ use threemf2::{
         transform::Transform,
         types::{OptionalResourceIndex, UuidResource},
     },
-    io::{
-        ThreemfPackage,
-        content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
-        relationship::{Relationship, RelationshipType, Relationships},
-    },
+    io::ThreemfPackageBuilder,
     threemf_namespaces::ThreemfNamespace,
 };
 
@@ -44,6 +39,12 @@ fn validate_boolean_model(model_xml: &str) {
         ],
         "Boolean Operations Schema",
     );
+}
+
+fn build_package(model: Model) -> threemf2::io::ThreemfPackage {
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    builder.build().expect("Error building package")
 }
 
 fn validate_boolean_with_production_model(model_xml: &str) {
@@ -446,105 +447,78 @@ fn validate_simple_boolean_difference() {
         }],
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]),
-            recommendedextensions: ThreemfExtensions::default(),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![
-                    Object {
-                        id: 1,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("Cube".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: None,
-                        kind: Some(ObjectKind::Mesh(cube_mesh)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                    Object {
-                        id: 2,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("Sphere".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: None,
-                        kind: Some(ObjectKind::Mesh(sphere_mesh)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                    Object {
-                        id: 3,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("CubeMinusSphere".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: None,
-                        kind: Some(ObjectKind::BooleanShape(boolean_shape)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                ],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![],
-                compositematerials: vec![],
-                texture2dgroup: vec![],
-                multiproperties: vec![],
-                texture2d: Vec::new(),
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
-                uuid: None,
-                item: vec![Item {
-                    objectid: 3,
-                    transform: None,
+    let write_package = build_package(Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]),
+        recommendedextensions: ThreemfExtensions::default(),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![
+                Object {
+                    id: 1,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
                     partnumber: None,
-                    path: None,
+                    name: Some("Cube".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
                     uuid: None,
-                }],
-            },
-        },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
+                    kind: Some(ObjectKind::Mesh(cube_mesh)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
                 },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
+                Object {
+                    id: 2,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
+                    partnumber: None,
+                    name: Some("Sphere".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
+                    uuid: None,
+                    kind: Some(ObjectKind::Mesh(sphere_mesh)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
+                },
+                Object {
+                    id: 3,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
+                    partnumber: None,
+                    name: Some("CubeMinusSphere".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
+                    uuid: None,
+                    kind: Some(ObjectKind::BooleanShape(boolean_shape)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
                 },
             ],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![],
+            compositematerials: vec![],
+            texture2dgroup: vec![],
+            multiproperties: vec![],
+            texture2d: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-    );
+        build: Build {
+            uuid: None,
+            item: vec![Item {
+                objectid: 3,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: None,
+            }],
+        },
+    });
 
     let mut buf = Cursor::new(Vec::new());
     write_package
@@ -577,105 +551,78 @@ fn validate_simple_boolean_intersection() {
         }],
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]),
-            recommendedextensions: ThreemfExtensions::default(),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![
-                    Object {
-                        id: 1,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("Cube".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: None,
-                        kind: Some(ObjectKind::Mesh(cube_mesh)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                    Object {
-                        id: 2,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("Sphere".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: None,
-                        kind: Some(ObjectKind::Mesh(sphere_mesh)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                    Object {
-                        id: 3,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("CubeIntersectSphere".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: None,
-                        kind: Some(ObjectKind::BooleanShape(boolean_shape)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                ],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![],
-                compositematerials: vec![],
-                texture2dgroup: vec![],
-                multiproperties: vec![],
-                texture2d: Vec::new(),
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
-                uuid: None,
-                item: vec![Item {
-                    objectid: 3,
-                    transform: None,
+    let write_package = build_package(Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]),
+        recommendedextensions: ThreemfExtensions::default(),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![
+                Object {
+                    id: 1,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
                     partnumber: None,
-                    path: None,
+                    name: Some("Cube".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
                     uuid: None,
-                }],
-            },
-        },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
+                    kind: Some(ObjectKind::Mesh(cube_mesh)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
                 },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
+                Object {
+                    id: 2,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
+                    partnumber: None,
+                    name: Some("Sphere".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
+                    uuid: None,
+                    kind: Some(ObjectKind::Mesh(sphere_mesh)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
+                },
+                Object {
+                    id: 3,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
+                    partnumber: None,
+                    name: Some("CubeIntersectSphere".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
+                    uuid: None,
+                    kind: Some(ObjectKind::BooleanShape(boolean_shape)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
                 },
             ],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![],
+            compositematerials: vec![],
+            texture2dgroup: vec![],
+            multiproperties: vec![],
+            texture2d: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-    );
+        build: Build {
+            uuid: None,
+            item: vec![Item {
+                objectid: 3,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: None,
+            }],
+        },
+    });
 
     let mut buf = Cursor::new(Vec::new());
     write_package
@@ -724,105 +671,78 @@ fn validate_boolean_with_multiple_operands() {
         ],
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]),
-            recommendedextensions: ThreemfExtensions::default(),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![
-                    Object {
-                        id: 1,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("Cube".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: None,
-                        kind: Some(ObjectKind::Mesh(cube_mesh)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                    Object {
-                        id: 2,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("Cylinder".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: None,
-                        kind: Some(ObjectKind::Mesh(cylinder_mesh)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                    Object {
-                        id: 3,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("CubeMinusThreeCylinders".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: None,
-                        kind: Some(ObjectKind::BooleanShape(boolean_shape)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                ],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![],
-                compositematerials: vec![],
-                texture2dgroup: vec![],
-                multiproperties: vec![],
-                texture2d: Vec::new(),
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
-                uuid: None,
-                item: vec![Item {
-                    objectid: 3,
-                    transform: None,
+    let write_package = build_package(Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]),
+        recommendedextensions: ThreemfExtensions::default(),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![
+                Object {
+                    id: 1,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
                     partnumber: None,
-                    path: None,
+                    name: Some("Cube".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
                     uuid: None,
-                }],
-            },
-        },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
+                    kind: Some(ObjectKind::Mesh(cube_mesh)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
                 },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
+                Object {
+                    id: 2,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
+                    partnumber: None,
+                    name: Some("Cylinder".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
+                    uuid: None,
+                    kind: Some(ObjectKind::Mesh(cylinder_mesh)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
+                },
+                Object {
+                    id: 3,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
+                    partnumber: None,
+                    name: Some("CubeMinusThreeCylinders".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
+                    uuid: None,
+                    kind: Some(ObjectKind::BooleanShape(boolean_shape)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
                 },
             ],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![],
+            compositematerials: vec![],
+            texture2dgroup: vec![],
+            multiproperties: vec![],
+            texture2d: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-    );
+        build: Build {
+            uuid: None,
+            item: vec![Item {
+                objectid: 3,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: None,
+            }],
+        },
+    });
 
     let mut buf = Cursor::new(Vec::new());
     write_package
@@ -871,133 +791,106 @@ fn validate_nested_boolean_shapes() {
         }],
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]),
-            recommendedextensions: ThreemfExtensions::default(),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![
-                    Object {
-                        id: 1,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("Cube".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: None,
-                        kind: Some(ObjectKind::Mesh(cube_mesh)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                    Object {
-                        id: 2,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("Sphere".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: None,
-                        kind: Some(ObjectKind::Mesh(sphere_mesh)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                    Object {
-                        id: 3,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("Intersected".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: None,
-                        kind: Some(ObjectKind::BooleanShape(intersected_shape)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                    Object {
-                        id: 4,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("Cylinder".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: None,
-                        kind: Some(ObjectKind::Mesh(cylinder_mesh)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                    Object {
-                        id: 5,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("FinalPart".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: None,
-                        kind: Some(ObjectKind::BooleanShape(final_shape)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                ],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![],
-                compositematerials: vec![],
-                texture2dgroup: vec![],
-                multiproperties: vec![],
-                texture2d: Vec::new(),
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
-                uuid: None,
-                item: vec![Item {
-                    objectid: 5,
-                    transform: None,
+    let write_package = build_package(Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]),
+        recommendedextensions: ThreemfExtensions::default(),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![
+                Object {
+                    id: 1,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
                     partnumber: None,
-                    path: None,
+                    name: Some("Cube".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
                     uuid: None,
-                }],
-            },
-        },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
+                    kind: Some(ObjectKind::Mesh(cube_mesh)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
                 },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
+                Object {
+                    id: 2,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
+                    partnumber: None,
+                    name: Some("Sphere".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
+                    uuid: None,
+                    kind: Some(ObjectKind::Mesh(sphere_mesh)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
+                },
+                Object {
+                    id: 3,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
+                    partnumber: None,
+                    name: Some("Intersected".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
+                    uuid: None,
+                    kind: Some(ObjectKind::BooleanShape(intersected_shape)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
+                },
+                Object {
+                    id: 4,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
+                    partnumber: None,
+                    name: Some("Cylinder".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
+                    uuid: None,
+                    kind: Some(ObjectKind::Mesh(cylinder_mesh)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
+                },
+                Object {
+                    id: 5,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
+                    partnumber: None,
+                    name: Some("FinalPart".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
+                    uuid: None,
+                    kind: Some(ObjectKind::BooleanShape(final_shape)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
                 },
             ],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![],
+            compositematerials: vec![],
+            texture2dgroup: vec![],
+            multiproperties: vec![],
+            texture2d: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-    );
+        build: Build {
+            uuid: None,
+            item: vec![Item {
+                objectid: 5,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: None,
+            }],
+        },
+    });
 
     let mut buf = Cursor::new(Vec::new());
     write_package
@@ -1029,115 +922,88 @@ fn validate_boolean_with_production_extension() {
         }],
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]),
-            recommendedextensions: ThreemfExtensions::default(),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![
-                    Object {
-                        id: 1,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("Cube".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: Some(UuidResource::NotUuid(
-                            "11111111-1111-1111-1111-111111111111".into(),
-                        )),
-                        kind: Some(ObjectKind::Mesh(cube_mesh)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                    Object {
-                        id: 2,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("Sphere".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: Some(UuidResource::NotUuid(
-                            "22222222-2222-2222-2222-222222222222".into(),
-                        )),
-                        kind: Some(ObjectKind::Mesh(sphere_mesh)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                    Object {
-                        id: 3,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("BooleanShapeWithUUID".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: Some(UuidResource::NotUuid(
-                            "33333333-3333-3333-3333-333333333333".into(),
-                        )),
-                        kind: Some(ObjectKind::BooleanShape(boolean_shape)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                ],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![],
-                compositematerials: vec![],
-                texture2dgroup: vec![],
-                multiproperties: vec![],
-                texture2d: Vec::new(),
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
-                uuid: Some(UuidResource::NotUuid(
-                    "44444444-4444-4444-4444-444444444444".into(),
-                )),
-                item: vec![Item {
-                    objectid: 3,
-                    transform: None,
+    let write_package = build_package(Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]),
+        recommendedextensions: ThreemfExtensions::default(),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![
+                Object {
+                    id: 1,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
                     partnumber: None,
-                    path: None,
+                    name: Some("Cube".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
                     uuid: Some(UuidResource::NotUuid(
-                        "55555555-5555-5555-5555-555555555555".into(),
+                        "11111111-1111-1111-1111-111111111111".into(),
                     )),
-                }],
-            },
-        },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
+                    kind: Some(ObjectKind::Mesh(cube_mesh)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
                 },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
+                Object {
+                    id: 2,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
+                    partnumber: None,
+                    name: Some("Sphere".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
+                    uuid: Some(UuidResource::NotUuid(
+                        "22222222-2222-2222-2222-222222222222".into(),
+                    )),
+                    kind: Some(ObjectKind::Mesh(sphere_mesh)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
+                },
+                Object {
+                    id: 3,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
+                    partnumber: None,
+                    name: Some("BooleanShapeWithUUID".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
+                    uuid: Some(UuidResource::NotUuid(
+                        "33333333-3333-3333-3333-333333333333".into(),
+                    )),
+                    kind: Some(ObjectKind::BooleanShape(boolean_shape)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
                 },
             ],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![],
+            compositematerials: vec![],
+            texture2dgroup: vec![],
+            multiproperties: vec![],
+            texture2d: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-    );
+        build: Build {
+            uuid: Some(UuidResource::NotUuid(
+                "44444444-4444-4444-4444-444444444444".into(),
+            )),
+            item: vec![Item {
+                objectid: 3,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: Some(UuidResource::NotUuid(
+                    "55555555-5555-5555-5555-555555555555".into(),
+                )),
+            }],
+        },
+    });
 
     let mut buf = Cursor::new(Vec::new());
     write_package

--- a/threemf2-xsd-validation/tests/combined_validation.rs
+++ b/threemf2-xsd-validation/tests/combined_validation.rs
@@ -2,7 +2,6 @@
 //!
 //! Tests validation of 3MF models that use multiple extensions simultaneously.
 
-use std::collections::HashMap;
 use std::io::Cursor;
 use threemf2::{
     core::{
@@ -16,11 +15,7 @@ use threemf2::{
         triangle_set::{TriangleRef, TriangleSet, TriangleSets},
         types::OptionalResourceIndex,
     },
-    io::{
-        ThreemfPackage,
-        content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
-        relationship::{Relationship, RelationshipType, Relationships},
-    },
+    io::ThreemfPackageBuilder,
     threemf_namespaces::ThreemfNamespace,
 };
 
@@ -170,78 +165,55 @@ fn validate_beamlattice_with_trianglesets() {
         beamlattice: Some(beamlattice),
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::new(&[
-                ThreemfNamespace::BeamLattice,
-                ThreemfNamespace::BeamLatticeBalls,
-            ]),
-            recommendedextensions: ThreemfExtensions::new(&[ThreemfNamespace::CoreTriangleSet]),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![Object {
-                    id: 1,
-                    objecttype: Some(ObjectType::Model),
-                    thumbnail: None,
-                    partnumber: None,
-                    name: Some("Beam Lattice with Triangle Sets".into()),
-                    pid: OptionalResourceId::none(),
-                    pindex: OptionalResourceIndex::none(),
-                    uuid: None,
-                    kind: Some(ObjectKind::Mesh(mesh)),
-                    meshresolution: None,
-                    slicestackid: OptionalResourceId::none(),
-                    slicepath: None,
-                }],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![],
-                compositematerials: vec![],
-                texture2dgroup: vec![],
-                multiproperties: vec![],
-                texture2d: Vec::new(),
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
+    let model = Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::new(&[
+            ThreemfNamespace::BeamLattice,
+            ThreemfNamespace::BeamLatticeBalls,
+        ]),
+        recommendedextensions: ThreemfExtensions::new(&[ThreemfNamespace::CoreTriangleSet]),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![Object {
+                id: 1,
+                objecttype: Some(ObjectType::Model),
+                thumbnail: None,
+                partnumber: None,
+                name: Some("Beam Lattice with Triangle Sets".into()),
+                pid: OptionalResourceId::none(),
+                pindex: OptionalResourceIndex::none(),
                 uuid: None,
-                item: vec![Item {
-                    objectid: 1,
-                    transform: None,
-                    partnumber: None,
-                    path: None,
-                    uuid: None,
-                }],
-            },
+                kind: Some(ObjectKind::Mesh(mesh)),
+                meshresolution: None,
+                slicestackid: OptionalResourceId::none(),
+                slicepath: None,
+            }],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![],
+            compositematerials: vec![],
+            texture2dgroup: vec![],
+            multiproperties: vec![],
+            texture2d: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
-                },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
-                },
-            ],
+        build: Build {
+            uuid: None,
+            item: vec![Item {
+                objectid: 1,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: None,
+            }],
         },
-    );
+    };
+
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    let write_package = builder.build().expect("Error building package");
 
     let mut buf = Cursor::new(Vec::new());
     write_package

--- a/threemf2-xsd-validation/tests/core_validation.rs
+++ b/threemf2-xsd-validation/tests/core_validation.rs
@@ -2,7 +2,6 @@
 //!
 //! Tests validation of basic 3MF models against the core specification XSD.
 
-use std::collections::HashMap;
 use std::io::Cursor;
 use threemf2::{
     core::{
@@ -15,11 +14,7 @@ use threemf2::{
         resources::Resources,
         types::OptionalResourceIndex,
     },
-    io::{
-        ThreemfPackage,
-        content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
-        relationship::{Relationship, RelationshipType, Relationships},
-    },
+    io::ThreemfPackageBuilder,
 };
 
 mod validation_utils;
@@ -87,75 +82,52 @@ fn validate_simple_mesh_against_core_xsd() {
         beamlattice: None,
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::default(),
-            recommendedextensions: ThreemfExtensions::default(),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![Object {
-                    id: 1,
-                    objecttype: Some(ObjectType::Model),
-                    thumbnail: None,
-                    partnumber: None,
-                    name: Some("Simple Mesh".into()),
-                    pid: OptionalResourceId::none(),
-                    pindex: OptionalResourceIndex::none(),
-                    uuid: None,
-                    kind: Some(ObjectKind::Mesh(mesh)),
-                    meshresolution: None,
-                    slicestackid: OptionalResourceId::none(),
-                    slicepath: None,
-                }],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![],
-                compositematerials: vec![],
-                texture2dgroup: vec![],
-                multiproperties: vec![],
-                texture2d: Vec::new(),
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
+    let model = Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::default(),
+        recommendedextensions: ThreemfExtensions::default(),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![Object {
+                id: 1,
+                objecttype: Some(ObjectType::Model),
+                thumbnail: None,
+                partnumber: None,
+                name: Some("Simple Mesh".into()),
+                pid: OptionalResourceId::none(),
+                pindex: OptionalResourceIndex::none(),
                 uuid: None,
-                item: vec![Item {
-                    objectid: 1,
-                    transform: None,
-                    partnumber: None,
-                    path: None,
-                    uuid: None,
-                }],
-            },
+                kind: Some(ObjectKind::Mesh(mesh)),
+                meshresolution: None,
+                slicestackid: OptionalResourceId::none(),
+                slicepath: None,
+            }],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![],
+            compositematerials: vec![],
+            texture2dgroup: vec![],
+            multiproperties: vec![],
+            texture2d: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
-                },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
-                },
-            ],
+        build: Build {
+            uuid: None,
+            item: vec![Item {
+                objectid: 1,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: None,
+            }],
         },
-    );
+    };
+
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    let write_package = builder.build().expect("Error building package");
 
     let mut buf = Cursor::new(Vec::new());
     write_package
@@ -233,86 +205,63 @@ fn validate_model_with_metadata_against_core_xsd() {
         beamlattice: None,
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::default(),
-            recommendedextensions: ThreemfExtensions::default(),
-            metadata: vec![
-                Metadata {
-                    name: "Title".into(),
-                    value: Some("Test Model".into()),
-                    preserve: Some(Preserve(false)),
-                },
-                Metadata {
-                    name: "Description".into(),
-                    value: Some("A test model for XSD validation".into()),
-                    preserve: Some(Preserve(false)),
-                },
-            ],
-            resources: Resources {
-                object: vec![Object {
-                    id: 1,
-                    objecttype: Some(ObjectType::Model),
-                    thumbnail: None,
-                    partnumber: None,
-                    name: Some("Mesh with Metadata".into()),
-                    pid: OptionalResourceId::none(),
-                    pindex: OptionalResourceIndex::none(),
-                    uuid: None,
-                    kind: Some(ObjectKind::Mesh(mesh)),
-                    meshresolution: None,
-                    slicestackid: OptionalResourceId::none(),
-                    slicepath: None,
-                }],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![],
-                compositematerials: vec![],
-                texture2dgroup: vec![],
-                multiproperties: vec![],
-                texture2d: Vec::new(),
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
+    let model = Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::default(),
+        recommendedextensions: ThreemfExtensions::default(),
+        metadata: vec![
+            Metadata {
+                name: "Title".into(),
+                value: Some("Test Model".into()),
+                preserve: Some(Preserve(false)),
             },
-            build: Build {
+            Metadata {
+                name: "Description".into(),
+                value: Some("A test model for XSD validation".into()),
+                preserve: Some(Preserve(false)),
+            },
+        ],
+        resources: Resources {
+            object: vec![Object {
+                id: 1,
+                objecttype: Some(ObjectType::Model),
+                thumbnail: None,
+                partnumber: None,
+                name: Some("Mesh with Metadata".into()),
+                pid: OptionalResourceId::none(),
+                pindex: OptionalResourceIndex::none(),
                 uuid: None,
-                item: vec![Item {
-                    objectid: 1,
-                    transform: None,
-                    partnumber: None,
-                    path: None,
-                    uuid: None,
-                }],
-            },
+                kind: Some(ObjectKind::Mesh(mesh)),
+                meshresolution: None,
+                slicestackid: OptionalResourceId::none(),
+                slicepath: None,
+            }],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![],
+            compositematerials: vec![],
+            texture2dgroup: vec![],
+            multiproperties: vec![],
+            texture2d: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
-                },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
-                },
-            ],
+        build: Build {
+            uuid: None,
+            item: vec![Item {
+                objectid: 1,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: None,
+            }],
         },
-    );
+    };
+
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    let write_package = builder.build().expect("Error building package");
 
     let mut buf = Cursor::new(Vec::new());
     write_package
@@ -396,75 +345,52 @@ fn validate_model_with_different_units() {
             beamlattice: None,
         };
 
-        let write_package = ThreemfPackage::new(
-            Model {
-                unit: Some(unit.clone()),
-                requiredextensions: ThreemfExtensions::default(),
-                recommendedextensions: ThreemfExtensions::default(),
-                metadata: vec![],
-                resources: Resources {
-                    object: vec![Object {
-                        id: 1,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some(format!("Mesh in {:?}", unit).into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: None,
-                        kind: Some(ObjectKind::Mesh(mesh)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    }],
-                    basematerials: vec![],
-                    slicestack: vec![],
-                    colorgroup: vec![],
-                    compositematerials: vec![],
-                    texture2dgroup: vec![],
-                    multiproperties: vec![],
-                    texture2d: Vec::new(),
-                    displacement2d: Vec::new(),
-                    normvectorgroup: Vec::new(),
-                    disp2dgroup: Vec::new(),
-                },
-                build: Build {
+        let model = Model {
+            unit: Some(unit.clone()),
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
+            metadata: vec![],
+            resources: Resources {
+                object: vec![Object {
+                    id: 1,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
+                    partnumber: None,
+                    name: Some(format!("Mesh in {:?}", unit).into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
                     uuid: None,
-                    item: vec![Item {
-                        objectid: 1,
-                        transform: None,
-                        partnumber: None,
-                        path: None,
-                        uuid: None,
-                    }],
-                },
+                    kind: Some(ObjectKind::Mesh(mesh)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
+                }],
+                basematerials: vec![],
+                slicestack: vec![],
+                colorgroup: vec![],
+                compositematerials: vec![],
+                texture2dgroup: vec![],
+                multiproperties: vec![],
+                texture2d: Vec::new(),
+                displacement2d: Vec::new(),
+                normvectorgroup: Vec::new(),
+                disp2dgroup: Vec::new(),
             },
-            HashMap::new(),
-            HashMap::new(),
-            HashMap::new(),
-            HashMap::from([(
-                "_rels/.rels".to_owned(),
-                Relationships {
-                    relationships: vec![Relationship {
-                        id: "rel0".to_owned(),
-                        target: "3D/3Dmodel.model".to_owned(),
-                        relationship_type: RelationshipType::Model,
-                    }],
-                },
-            )]),
-            ContentTypes {
-                defaults: vec![
-                    DefaultContentTypes {
-                        extension: "rels".to_owned(),
-                        content_type: DefaultContentTypeEnum::Relationship,
-                    },
-                    DefaultContentTypes {
-                        extension: "model".to_owned(),
-                        content_type: DefaultContentTypeEnum::Model,
-                    },
-                ],
+            build: Build {
+                uuid: None,
+                item: vec![Item {
+                    objectid: 1,
+                    transform: None,
+                    partnumber: None,
+                    path: None,
+                    uuid: None,
+                }],
             },
-        );
+        };
+
+        let mut builder = ThreemfPackageBuilder::new();
+        builder.set_root_model(model);
+        let write_package = builder.build().expect("Error building package");
 
         let mut buf = Cursor::new(Vec::new());
         write_package

--- a/threemf2-xsd-validation/tests/displacement_validation.rs
+++ b/threemf2-xsd-validation/tests/displacement_validation.rs
@@ -1,6 +1,5 @@
 //! Displacement extension XSD validation tests
 
-use std::collections::HashMap;
 use std::io::Cursor;
 
 use threemf2::{
@@ -15,11 +14,7 @@ use threemf2::{
         object::{Object, ObjectKind, ObjectType},
         resources::Resources,
     },
-    io::{
-        ThreemfPackage,
-        content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
-        relationship::{Relationship, RelationshipType, Relationships},
-    },
+    io::ThreemfPackageBuilder,
     threemf_namespaces::ThreemfNamespace,
 };
 
@@ -210,34 +205,9 @@ fn validate_displacement_model_schema() {
         },
     };
 
-    let package = ThreemfPackage::new(
-        model,
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
-                },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
-                },
-            ],
-        },
-    );
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    let package = builder.build().expect("Error building package");
 
     let mut buf = Cursor::new(Vec::new());
     package.write(&mut buf).expect("Error writing package");

--- a/threemf2-xsd-validation/tests/material_validation.rs
+++ b/threemf2-xsd-validation/tests/material_validation.rs
@@ -3,7 +3,6 @@
 //! Tests validation of 3MF models with material extension structures against
 //! the Material extension XSD schemas.
 
-use std::collections::HashMap;
 use std::io::Cursor;
 use threemf2::{
     core::{
@@ -19,11 +18,7 @@ use threemf2::{
         resources::Resources,
         types::{Double, ResourceIdCollection, ResourceIndexCollection},
     },
-    io::{
-        ThreemfPackage,
-        content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
-        relationship::{Relationship, RelationshipType, Relationships},
-    },
+    io::ThreemfPackageBuilder,
     threemf_namespaces::ThreemfNamespace,
 };
 
@@ -127,75 +122,52 @@ fn validate_simple_colorgroup() {
         beamlattice: None,
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Material]),
-            recommendedextensions: ThreemfExtensions::default(),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![Object {
-                    id: 1,
-                    objecttype: Some(ObjectType::Model),
-                    thumbnail: None,
-                    partnumber: None,
-                    name: Some("Colored Mesh".into()),
-                    pid: OptionalResourceId::none(),
-                    pindex: OptionalResourceIndex::none(),
-                    uuid: None,
-                    kind: Some(ObjectKind::Mesh(mesh)),
-                    meshresolution: None,
-                    slicestackid: OptionalResourceId::none(),
-                    slicepath: None,
-                }],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![colorgroup],
-                compositematerials: vec![],
-                texture2dgroup: vec![],
-                multiproperties: vec![],
-                texture2d: Vec::new(),
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
+    let model = Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Material]),
+        recommendedextensions: ThreemfExtensions::default(),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![Object {
+                id: 1,
+                objecttype: Some(ObjectType::Model),
+                thumbnail: None,
+                partnumber: None,
+                name: Some("Colored Mesh".into()),
+                pid: OptionalResourceId::none(),
+                pindex: OptionalResourceIndex::none(),
                 uuid: None,
-                item: vec![Item {
-                    objectid: 1,
-                    transform: None,
-                    partnumber: None,
-                    path: None,
-                    uuid: None,
-                }],
-            },
+                kind: Some(ObjectKind::Mesh(mesh)),
+                meshresolution: None,
+                slicestackid: OptionalResourceId::none(),
+                slicepath: None,
+            }],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![colorgroup],
+            compositematerials: vec![],
+            texture2dgroup: vec![],
+            multiproperties: vec![],
+            texture2d: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
-                },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
-                },
-            ],
+        build: Build {
+            uuid: None,
+            item: vec![Item {
+                objectid: 1,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: None,
+            }],
         },
-    );
+    };
+
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    let write_package = builder.build().expect("Error building package");
 
     let mut buf = Cursor::new(Vec::new());
     write_package
@@ -299,75 +271,52 @@ fn validate_texture2d_with_uv_mapping() {
         beamlattice: None,
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Material]),
-            recommendedextensions: ThreemfExtensions::default(),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![Object {
-                    id: 1,
-                    objecttype: Some(ObjectType::Model),
-                    thumbnail: None,
-                    partnumber: None,
-                    name: Some("Textured Mesh".into()),
-                    pid: OptionalResourceId::new(2), // Reference texture group
-                    pindex: OptionalResourceIndex::none(),
-                    uuid: None,
-                    kind: Some(ObjectKind::Mesh(mesh)),
-                    meshresolution: None,
-                    slicestackid: OptionalResourceId::none(),
-                    slicepath: None,
-                }],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![],
-                compositematerials: vec![],
-                texture2dgroup: vec![texture2dgroup],
-                multiproperties: vec![],
-                texture2d: vec![texture2d],
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
+    let model = Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Material]),
+        recommendedextensions: ThreemfExtensions::default(),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![Object {
+                id: 1,
+                objecttype: Some(ObjectType::Model),
+                thumbnail: None,
+                partnumber: None,
+                name: Some("Textured Mesh".into()),
+                pid: OptionalResourceId::new(2), // Reference texture group
+                pindex: OptionalResourceIndex::none(),
                 uuid: None,
-                item: vec![Item {
-                    objectid: 1,
-                    transform: None,
-                    partnumber: None,
-                    path: None,
-                    uuid: None,
-                }],
-            },
+                kind: Some(ObjectKind::Mesh(mesh)),
+                meshresolution: None,
+                slicestackid: OptionalResourceId::none(),
+                slicepath: None,
+            }],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![],
+            compositematerials: vec![],
+            texture2dgroup: vec![texture2dgroup],
+            multiproperties: vec![],
+            texture2d: vec![texture2d],
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
-                },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
-                },
-            ],
+        build: Build {
+            uuid: None,
+            item: vec![Item {
+                objectid: 1,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: None,
+            }],
         },
-    );
+    };
+
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    let write_package = builder.build().expect("Error building package");
 
     let mut buf = Cursor::new(Vec::new());
     write_package
@@ -504,75 +453,52 @@ fn validate_multi_properties() {
         beamlattice: None,
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Material]),
-            recommendedextensions: ThreemfExtensions::default(),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![Object {
-                    id: 1,
-                    objecttype: Some(ObjectType::Model),
-                    thumbnail: None,
-                    partnumber: None,
-                    name: Some("Multi Property Mesh".into()),
-                    pid: OptionalResourceId::none(),
-                    pindex: OptionalResourceIndex::none(),
-                    uuid: None,
-                    kind: Some(ObjectKind::Mesh(mesh)),
-                    meshresolution: None,
-                    slicestackid: OptionalResourceId::none(),
-                    slicepath: None,
-                }],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![colorgroup],
-                compositematerials: vec![],
-                texture2dgroup: vec![texture2dgroup],
-                multiproperties: vec![multiproperties],
-                texture2d: vec![texture2d],
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
+    let model = Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Material]),
+        recommendedextensions: ThreemfExtensions::default(),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![Object {
+                id: 1,
+                objecttype: Some(ObjectType::Model),
+                thumbnail: None,
+                partnumber: None,
+                name: Some("Multi Property Mesh".into()),
+                pid: OptionalResourceId::none(),
+                pindex: OptionalResourceIndex::none(),
                 uuid: None,
-                item: vec![Item {
-                    objectid: 1,
-                    transform: None,
-                    partnumber: None,
-                    path: None,
-                    uuid: None,
-                }],
-            },
+                kind: Some(ObjectKind::Mesh(mesh)),
+                meshresolution: None,
+                slicestackid: OptionalResourceId::none(),
+                slicepath: None,
+            }],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![colorgroup],
+            compositematerials: vec![],
+            texture2dgroup: vec![texture2dgroup],
+            multiproperties: vec![multiproperties],
+            texture2d: vec![texture2d],
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
-                },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
-                },
-            ],
+        build: Build {
+            uuid: None,
+            item: vec![Item {
+                objectid: 1,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: None,
+            }],
         },
-    );
+    };
+
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    let write_package = builder.build().expect("Error building package");
 
     let mut buf = Cursor::new(Vec::new());
     write_package
@@ -674,75 +600,52 @@ fn validate_vertex_color_application() {
         beamlattice: None,
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Material]),
-            recommendedextensions: ThreemfExtensions::default(),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![Object {
-                    id: 1,
-                    objecttype: Some(ObjectType::Model),
-                    thumbnail: None,
-                    partnumber: None,
-                    name: Some("Vertex Colored Quad".into()),
-                    pid: OptionalResourceId::none(),
-                    pindex: OptionalResourceIndex::none(),
-                    uuid: None,
-                    kind: Some(ObjectKind::Mesh(mesh)),
-                    meshresolution: None,
-                    slicestackid: OptionalResourceId::none(),
-                    slicepath: None,
-                }],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![colorgroup],
-                compositematerials: vec![],
-                texture2dgroup: vec![],
-                multiproperties: vec![],
-                texture2d: Vec::new(),
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
+    let model = Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Material]),
+        recommendedextensions: ThreemfExtensions::default(),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![Object {
+                id: 1,
+                objecttype: Some(ObjectType::Model),
+                thumbnail: None,
+                partnumber: None,
+                name: Some("Vertex Colored Quad".into()),
+                pid: OptionalResourceId::none(),
+                pindex: OptionalResourceIndex::none(),
                 uuid: None,
-                item: vec![Item {
-                    objectid: 1,
-                    transform: None,
-                    partnumber: None,
-                    path: None,
-                    uuid: None,
-                }],
-            },
+                kind: Some(ObjectKind::Mesh(mesh)),
+                meshresolution: None,
+                slicestackid: OptionalResourceId::none(),
+                slicepath: None,
+            }],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![colorgroup],
+            compositematerials: vec![],
+            texture2dgroup: vec![],
+            multiproperties: vec![],
+            texture2d: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
-                },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
-                },
-            ],
+        build: Build {
+            uuid: None,
+            item: vec![Item {
+                objectid: 1,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: None,
+            }],
         },
-    );
+    };
+
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    let write_package = builder.build().expect("Error building package");
 
     let mut buf = Cursor::new(Vec::new());
     write_package

--- a/threemf2-xsd-validation/tests/production_validation.rs
+++ b/threemf2-xsd-validation/tests/production_validation.rs
@@ -3,7 +3,6 @@
 //! Tests validation of 3MF models with Production extension features (UUIDs, paths)
 //! against the Production extension XSD schemas.
 
-use std::collections::HashMap;
 use std::io::Cursor;
 use threemf2::{
     core::{
@@ -16,11 +15,7 @@ use threemf2::{
         resources::Resources,
         types::OptionalResourceIndex,
     },
-    io::{
-        ThreemfPackage,
-        content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
-        relationship::{Relationship, RelationshipType, Relationships},
-    },
+    io::ThreemfPackageBuilder,
     threemf_namespaces::ThreemfNamespace,
 };
 
@@ -105,75 +100,52 @@ fn validate_simple_production_model_with_uuids() {
         beamlattice: None,
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Prod]),
-            recommendedextensions: ThreemfExtensions::default(),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![Object {
-                    id: 1,
-                    objecttype: Some(ObjectType::Model),
-                    thumbnail: None,
-                    partnumber: None,
-                    name: Some("Production Model".into()),
-                    pid: OptionalResourceId::none(),
-                    pindex: OptionalResourceIndex::none(),
-                    uuid: Some(UuidResource::from("01cbb956-1d24-062d-fbe6-7362e5727594")),
-                    kind: Some(ObjectKind::Mesh(mesh)),
-                    meshresolution: None,
-                    slicestackid: OptionalResourceId::none(),
-                    slicepath: None,
-                }],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![],
-                compositematerials: vec![],
-                texture2dgroup: vec![],
-                multiproperties: vec![],
-                texture2d: Vec::new(),
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
-                uuid: Some(UuidResource::from("96681a5d-5b0f-e592-8c51-da7ed587cb5f")),
-                item: vec![Item {
-                    objectid: 1,
-                    transform: None,
-                    partnumber: None,
-                    path: None,
-                    uuid: Some(UuidResource::from("b3de5826-ccb6-3dbc-d6c4-29a2d730766c")),
-                }],
-            },
+    let model = Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Prod]),
+        recommendedextensions: ThreemfExtensions::default(),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![Object {
+                id: 1,
+                objecttype: Some(ObjectType::Model),
+                thumbnail: None,
+                partnumber: None,
+                name: Some("Production Model".into()),
+                pid: OptionalResourceId::none(),
+                pindex: OptionalResourceIndex::none(),
+                uuid: Some(UuidResource::from("01cbb956-1d24-062d-fbe6-7362e5727594")),
+                kind: Some(ObjectKind::Mesh(mesh)),
+                meshresolution: None,
+                slicestackid: OptionalResourceId::none(),
+                slicepath: None,
+            }],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![],
+            compositematerials: vec![],
+            texture2dgroup: vec![],
+            multiproperties: vec![],
+            texture2d: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
-                },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
-                },
-            ],
+        build: Build {
+            uuid: Some(UuidResource::from("96681a5d-5b0f-e592-8c51-da7ed587cb5f")),
+            item: vec![Item {
+                objectid: 1,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: Some(UuidResource::from("b3de5826-ccb6-3dbc-d6c4-29a2d730766c")),
+            }],
         },
-    );
+    };
+
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    let write_package = builder.build().expect("Error building package");
 
     let mut buf = Cursor::new(Vec::new());
     write_package
@@ -258,111 +230,88 @@ fn validate_production_model_with_components() {
         uuid: Some(UuidResource::from("comp-uuid-1234-5678-90ab-cdef12345678")),
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Prod]),
-            recommendedextensions: ThreemfExtensions::default(),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![
-                    Object {
-                        id: 1,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("Component Part 1".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: Some(UuidResource::from("uuid-part1-1234-5678-90ab-cdef12345678")),
-                        kind: Some(ObjectKind::Mesh(mesh1)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                    Object {
-                        id: 2,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("Component Part 2".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: Some(UuidResource::from("uuid-part2-1234-5678-90ab-cdef12345678")),
-                        kind: Some(ObjectKind::Mesh(mesh2)),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                    Object {
-                        id: 3,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("Assembly".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: Some(UuidResource::from(
-                            "uuid-assembly-1234-5678-90ab-cdef12345678",
-                        )),
-                        kind: Some(ObjectKind::Components(
-                            threemf2::core::component::Components {
-                                component: vec![component],
-                            },
-                        )),
-                        meshresolution: None,
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                    },
-                ],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![],
-                compositematerials: vec![],
-                texture2dgroup: vec![],
-                multiproperties: vec![],
-                texture2d: Vec::new(),
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
-                uuid: Some(UuidResource::from("build-uuid-1234-5678-90ab-cdef12345678")),
-                item: vec![Item {
-                    objectid: 3,
-                    transform: None,
+    let model = Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Prod]),
+        recommendedextensions: ThreemfExtensions::default(),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![
+                Object {
+                    id: 1,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
                     partnumber: None,
-                    path: None,
-                    uuid: Some(UuidResource::from("item-uuid-1234-5678-90ab-cdef12345678")),
-                }],
-            },
-        },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
+                    name: Some("Component Part 1".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
+                    uuid: Some(UuidResource::from("uuid-part1-1234-5678-90ab-cdef12345678")),
+                    kind: Some(ObjectKind::Mesh(mesh1)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
                 },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
+                Object {
+                    id: 2,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
+                    partnumber: None,
+                    name: Some("Component Part 2".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
+                    uuid: Some(UuidResource::from("uuid-part2-1234-5678-90ab-cdef12345678")),
+                    kind: Some(ObjectKind::Mesh(mesh2)),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
+                },
+                Object {
+                    id: 3,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
+                    partnumber: None,
+                    name: Some("Assembly".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
+                    uuid: Some(UuidResource::from(
+                        "uuid-assembly-1234-5678-90ab-cdef12345678",
+                    )),
+                    kind: Some(ObjectKind::Components(
+                        threemf2::core::component::Components {
+                            component: vec![component],
+                        },
+                    )),
+                    meshresolution: None,
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
                 },
             ],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![],
+            compositematerials: vec![],
+            texture2dgroup: vec![],
+            multiproperties: vec![],
+            texture2d: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-    );
+        build: Build {
+            uuid: Some(UuidResource::from("build-uuid-1234-5678-90ab-cdef12345678")),
+            item: vec![Item {
+                objectid: 3,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: Some(UuidResource::from("item-uuid-1234-5678-90ab-cdef12345678")),
+            }],
+        },
+    };
+
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    let write_package = builder.build().expect("Error building package");
 
     let mut buf = Cursor::new(Vec::new());
     write_package

--- a/threemf2-xsd-validation/tests/slice_validation.rs
+++ b/threemf2-xsd-validation/tests/slice_validation.rs
@@ -3,7 +3,6 @@
 //! Tests validation of 3MF models with slice data against
 //! the Slice extension XSD schema.
 
-use std::collections::HashMap;
 use std::io::Cursor;
 use threemf2::{
     core::{
@@ -15,11 +14,7 @@ use threemf2::{
         resources::Resources,
         slice::{self, MeshResolution, Polygon, Segment, Slice, SliceStack},
     },
-    io::{
-        ThreemfPackage,
-        content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
-        relationship::{Relationship, RelationshipType, Relationships},
-    },
+    io::ThreemfPackageBuilder,
     threemf_namespaces::ThreemfNamespace,
 };
 
@@ -192,34 +187,9 @@ fn validate_simple_slice() {
 
     // Write to buffer
     let mut buf = Cursor::new(Vec::new());
-    let package = ThreemfPackage::new(
-        model,
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
-                },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
-                },
-            ],
-        },
-    );
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    let package = builder.build().expect("Error building package");
     package.write(&mut buf).expect("Error writing");
 
     // Extract and validate
@@ -427,34 +397,9 @@ fn validate_slice_multiple_polygons() {
 
     // Write and validate
     let mut buf = Cursor::new(Vec::new());
-    let package = ThreemfPackage::new(
-        model,
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
-                },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
-                },
-            ],
-        },
-    );
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    let package = builder.build().expect("Error building package");
     package.write(&mut buf).expect("Error writing");
 
     let model_xml = extract_model_xml(buf.get_ref()).unwrap();

--- a/threemf2-xsd-validation/tests/trianglesets_validation.rs
+++ b/threemf2-xsd-validation/tests/trianglesets_validation.rs
@@ -3,7 +3,6 @@
 //! Tests validation of 3MF models with Triangle Sets against
 //! the Core Triangle Sets extension XSD schema.
 
-use std::collections::HashMap;
 use std::io::Cursor;
 use threemf2::{
     core::{
@@ -16,11 +15,7 @@ use threemf2::{
         triangle_set::{TriangleRef, TriangleRefRange, TriangleSet, TriangleSets},
         types::OptionalResourceIndex,
     },
-    io::{
-        ThreemfPackage,
-        content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
-        relationship::{Relationship, RelationshipType, Relationships},
-    },
+    io::ThreemfPackageBuilder,
     threemf_namespaces::ThreemfNamespace,
 };
 
@@ -120,75 +115,52 @@ fn validate_simple_trianglesets() {
         beamlattice: None,
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::default(),
-            recommendedextensions: ThreemfExtensions::new(&[ThreemfNamespace::CoreTriangleSet]),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![Object {
-                    id: 1,
-                    objecttype: Some(ObjectType::Model),
-                    thumbnail: None,
-                    partnumber: None,
-                    name: Some("Mesh with Triangle Sets".into()),
-                    pid: OptionalResourceId::none(),
-                    pindex: OptionalResourceIndex::none(),
-                    uuid: None,
-                    kind: Some(ObjectKind::Mesh(mesh)),
-                    meshresolution: None,
-                    slicestackid: OptionalResourceId::none(),
-                    slicepath: None,
-                }],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![],
-                compositematerials: vec![],
-                texture2dgroup: vec![],
-                multiproperties: vec![],
-                texture2d: Vec::new(),
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
+    let model = Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::default(),
+        recommendedextensions: ThreemfExtensions::new(&[ThreemfNamespace::CoreTriangleSet]),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![Object {
+                id: 1,
+                objecttype: Some(ObjectType::Model),
+                thumbnail: None,
+                partnumber: None,
+                name: Some("Mesh with Triangle Sets".into()),
+                pid: OptionalResourceId::none(),
+                pindex: OptionalResourceIndex::none(),
                 uuid: None,
-                item: vec![Item {
-                    objectid: 1,
-                    transform: None,
-                    partnumber: None,
-                    path: None,
-                    uuid: None,
-                }],
-            },
+                kind: Some(ObjectKind::Mesh(mesh)),
+                meshresolution: None,
+                slicestackid: OptionalResourceId::none(),
+                slicepath: None,
+            }],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![],
+            compositematerials: vec![],
+            texture2dgroup: vec![],
+            multiproperties: vec![],
+            texture2d: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
-                },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
-                },
-            ],
+        build: Build {
+            uuid: None,
+            item: vec![Item {
+                objectid: 1,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: None,
+            }],
         },
-    );
+    };
+
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    let write_package = builder.build().expect("Error building package");
 
     let mut buf = Cursor::new(Vec::new());
     write_package
@@ -265,75 +237,52 @@ fn validate_trianglesets_with_ref_ranges() {
         beamlattice: None,
     };
 
-    let write_package = ThreemfPackage::new(
-        Model {
-            unit: Some(Unit::Millimeter),
-            requiredextensions: ThreemfExtensions::default(),
-            recommendedextensions: ThreemfExtensions::new(&[ThreemfNamespace::CoreTriangleSet]),
-            metadata: vec![],
-            resources: Resources {
-                object: vec![Object {
-                    id: 1,
-                    objecttype: Some(ObjectType::Model),
-                    thumbnail: None,
-                    partnumber: None,
-                    name: Some("Mesh with Triangle Set Ranges".into()),
-                    pid: OptionalResourceId::none(),
-                    pindex: OptionalResourceIndex::none(),
-                    uuid: None,
-                    kind: Some(ObjectKind::Mesh(mesh)),
-                    meshresolution: None,
-                    slicestackid: OptionalResourceId::none(),
-                    slicepath: None,
-                }],
-                basematerials: vec![],
-                slicestack: vec![],
-                colorgroup: vec![],
-                compositematerials: vec![],
-                texture2dgroup: vec![],
-                multiproperties: vec![],
-                texture2d: Vec::new(),
-                displacement2d: Vec::new(),
-                normvectorgroup: Vec::new(),
-                disp2dgroup: Vec::new(),
-            },
-            build: Build {
+    let model = Model {
+        unit: Some(Unit::Millimeter),
+        requiredextensions: ThreemfExtensions::default(),
+        recommendedextensions: ThreemfExtensions::new(&[ThreemfNamespace::CoreTriangleSet]),
+        metadata: vec![],
+        resources: Resources {
+            object: vec![Object {
+                id: 1,
+                objecttype: Some(ObjectType::Model),
+                thumbnail: None,
+                partnumber: None,
+                name: Some("Mesh with Triangle Set Ranges".into()),
+                pid: OptionalResourceId::none(),
+                pindex: OptionalResourceIndex::none(),
                 uuid: None,
-                item: vec![Item {
-                    objectid: 1,
-                    transform: None,
-                    partnumber: None,
-                    path: None,
-                    uuid: None,
-                }],
-            },
+                kind: Some(ObjectKind::Mesh(mesh)),
+                meshresolution: None,
+                slicestackid: OptionalResourceId::none(),
+                slicepath: None,
+            }],
+            basematerials: vec![],
+            slicestack: vec![],
+            colorgroup: vec![],
+            compositematerials: vec![],
+            texture2dgroup: vec![],
+            multiproperties: vec![],
+            texture2d: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         },
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::from([(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3Dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        )]),
-        ContentTypes {
-            defaults: vec![
-                DefaultContentTypes {
-                    extension: "rels".to_owned(),
-                    content_type: DefaultContentTypeEnum::Relationship,
-                },
-                DefaultContentTypes {
-                    extension: "model".to_owned(),
-                    content_type: DefaultContentTypeEnum::Model,
-                },
-            ],
+        build: Build {
+            uuid: None,
+            item: vec![Item {
+                objectid: 1,
+                transform: None,
+                partnumber: None,
+                path: None,
+                uuid: None,
+            }],
         },
-    );
+    };
+
+    let mut builder = ThreemfPackageBuilder::new();
+    builder.set_root_model(model);
+    let write_package = builder.build().expect("Error building package");
 
     let mut buf = Cursor::new(Vec::new());
     write_package

--- a/threemf2/examples/beamlattice_write.rs
+++ b/threemf2/examples/beamlattice_write.rs
@@ -1,17 +1,5 @@
-use threemf2::{
-    core::{
-        OptionalResourceId, OptionalResourceIndex,
-        beamlattice::{Ball, BallMode, Balls, Beam, BeamLattice, Beams, CapMode},
-        build::{Build, Item},
-        mesh::{Mesh, Triangles, Vertex, Vertices},
-        metadata::Metadata,
-        model::{Model, ThreemfExtensions, Unit},
-        object::{Object, ObjectKind, ObjectType},
-        resources::Resources,
-    },
-    io::ThreemfPackage,
-    threemf_namespaces::ThreemfNamespace,
-};
+use threemf2::core::builder::{BallMode, CapMode, ModelBuilder, ObjectType, Unit};
+use threemf2::io::ThreemfPackage;
 
 use std::{io::Cursor, vec};
 
@@ -22,257 +10,73 @@ use std::{io::Cursor, vec};
 /// `cargo run --example beamlattice_write --no-default-features --features io-write`
 ///
 fn main() {
-    // Create vertices for a simple cube structure
-    let vertices = Vertices {
-        vertex: vec![
-            Vertex::new(45.0, 55.0, 55.0),
-            Vertex::new(45.0, 45.0, 55.0),
-            Vertex::new(45.0, 55.0, 45.0),
-            Vertex::new(45.0, 45.0, 45.0),
-            Vertex::new(55.0, 55.0, 45.0),
-            Vertex::new(55.0, 55.0, 55.0),
-            Vertex::new(55.0, 45.0, 55.0),
-            Vertex::new(55.0, 45.0, 45.0),
-        ],
-    };
+    let mut builder = ModelBuilder::new(Unit::Millimeter, true);
+    builder
+        .add_metadata("Beam Lattice Example", None)
+        .add_build(None)
+        .unwrap();
 
-    // Create beams connecting the vertices
-    let beams = Beams {
-        beam: vec![
-            Beam {
-                v1: 0,
-                v2: 1,
-                r1: Some(1.5),
-                r2: Some(1.6),
-                p1: OptionalResourceIndex::none(),
-                p2: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-                cap1: None,
-                cap2: None,
-            },
-            Beam {
-                v1: 2,
-                v2: 0,
-                r1: Some(3.0),
-                r2: Some(1.5),
-                p1: OptionalResourceIndex::none(),
-                p2: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-                cap1: None,
-                cap2: None,
-            },
-            Beam {
-                v1: 1,
-                v2: 3,
-                r1: Some(1.6),
-                r2: Some(3.0),
-                p1: OptionalResourceIndex::none(),
-                p2: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-                cap1: None,
-                cap2: None,
-            },
-            Beam {
-                v1: 3,
-                v2: 2,
-                r1: Some(3.0),
-                r2: None,
-                p1: OptionalResourceIndex::none(),
-                p2: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-                cap1: None,
-                cap2: None,
-            },
-            Beam {
-                v1: 2,
-                v2: 4,
-                r1: Some(3.0),
-                r2: Some(2.0),
-                p1: OptionalResourceIndex::none(),
-                p2: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-                cap1: None,
-                cap2: None,
-            },
-            Beam {
-                v1: 4,
-                v2: 5,
-                r1: Some(2.0),
-                r2: None,
-                p1: OptionalResourceIndex::none(),
-                p2: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-                cap1: None,
-                cap2: None,
-            },
-            Beam {
-                v1: 5,
-                v2: 6,
-                r1: Some(2.0),
-                r2: None,
-                p1: OptionalResourceIndex::none(),
-                p2: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-                cap1: None,
-                cap2: None,
-            },
-            Beam {
-                v1: 7,
-                v2: 6,
-                r1: Some(2.0),
-                r2: None,
-                p1: OptionalResourceIndex::none(),
-                p2: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-                cap1: None,
-                cap2: None,
-            },
-            Beam {
-                v1: 1,
-                v2: 6,
-                r1: Some(1.6),
-                r2: Some(2.0),
-                p1: OptionalResourceIndex::none(),
-                p2: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-                cap1: None,
-                cap2: None,
-            },
-            Beam {
-                v1: 7,
-                v2: 4,
-                r1: Some(2.0),
-                r2: None,
-                p1: OptionalResourceIndex::none(),
-                p2: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-                cap1: None,
-                cap2: None,
-            },
-            Beam {
-                v1: 7,
-                v2: 3,
-                r1: Some(2.0),
-                r2: Some(3.0),
-                p1: OptionalResourceIndex::none(),
-                p2: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-                cap1: None,
-                cap2: None,
-            },
-            Beam {
-                v1: 0,
-                v2: 5,
-                r1: Some(1.5),
-                r2: Some(2.0),
-                p1: OptionalResourceIndex::none(),
-                p2: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-                cap1: None,
-                cap2: None,
-            },
-        ],
-    };
+    let beam_defs = vec![
+        (0, 1, Some(1.5), Some(1.6)),
+        (2, 0, Some(3.0), Some(1.5)),
+        (1, 3, Some(1.6), Some(3.0)),
+        (3, 2, Some(3.0), None),
+        (2, 4, Some(3.0), Some(2.0)),
+        (4, 5, Some(2.0), None),
+        (5, 6, Some(2.0), None),
+        (7, 6, Some(2.0), None),
+        (1, 6, Some(1.6), Some(2.0)),
+        (7, 4, Some(2.0), None),
+        (7, 3, Some(2.0), Some(3.0)),
+        (0, 5, Some(1.5), Some(2.0)),
+    ];
 
-    // Create balls at some vertices for a mixed ball mode example
-    let balls = Some(Balls {
-        ball: vec![
-            Ball {
-                vindex: 0,
-                r: Some(0.5),
-                p: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-            },
-            Ball {
-                vindex: 5,
-                r: None,
-                p: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-            }, // Uses default ballradius
-            Ball {
-                vindex: 7,
-                r: Some(0.5),
-                p: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-            },
-        ],
-    });
+    let ball_defs = vec![(0, Some(0.5)), (5, None), (7, Some(0.5))];
 
-    // Create the beam lattice
-    let beam_lattice = BeamLattice {
-        minlength: 0.0001,
-        radius: 1.0,
-        ballmode: Some(BallMode::Mixed),
-        ballradius: Some(0.25),
-        clippingmode: None,
-        clippingmesh: OptionalResourceId::none(),
-        representationmesh: OptionalResourceId::none(),
-        pid: OptionalResourceId::none(),
-        pindex: OptionalResourceIndex::none(),
-        cap: Some(CapMode::Sphere),
-        beams,
-        balls,
-        beamsets: None,
-    };
+    let object_id = builder
+        .add_mesh_object(|obj| {
+            obj.object_type(ObjectType::Model)
+                .part_number("beam-lattice-example")
+                .name("Beam Lattice Cube");
 
-    // Create a mesh with the beam lattice (no triangles for lattice-only object)
-    let mesh = Mesh {
-        vertices,
-        triangles: Triangles { triangle: vec![] },
-        trianglesets: None,
-        beamlattice: Some(beam_lattice),
-    };
+            obj.add_vertices(&[
+                [45.0, 55.0, 55.0],
+                [45.0, 45.0, 55.0],
+                [45.0, 55.0, 45.0],
+                [45.0, 45.0, 45.0],
+                [55.0, 55.0, 45.0],
+                [55.0, 55.0, 55.0],
+                [55.0, 45.0, 55.0],
+                [55.0, 45.0, 45.0],
+            ]);
 
-    // Create the complete 3MF model
-    let model = Model {
-        unit: Some(Unit::Millimeter),
-        requiredextensions: ThreemfExtensions::new(&[
-            ThreemfNamespace::BeamLattice,
-            ThreemfNamespace::BeamLatticeBalls,
-        ]), // Mark beam lattice extensions as required
-        recommendedextensions: ThreemfExtensions::default(),
-        metadata: vec![Metadata {
-            name: "Beam Lattice Example".into(),
-            preserve: None,
-            value: None,
-        }],
-        resources: Resources {
-            object: vec![Object {
-                id: 1,
-                objecttype: Some(ObjectType::Model),
-                thumbnail: None,
-                partnumber: Some("beam-lattice-example".into()),
-                name: Some("Beam Lattice Cube".into()),
-                pid: OptionalResourceId::none(),
-                pindex: OptionalResourceIndex::none(),
-                uuid: None,
-                slicestackid: OptionalResourceId::none(),
-                slicepath: None,
-                meshresolution: None,
-                kind: Some(ObjectKind::Mesh(mesh)),
-            }],
-            basematerials: vec![],
-            slicestack: vec![],
-            colorgroup: Vec::new(),
-            texture2dgroup: Vec::new(),
-            compositematerials: Vec::new(),
-            multiproperties: Vec::new(),
-            texture2d: Vec::new(),
-            displacement2d: Vec::new(),
-            normvectorgroup: Vec::new(),
-            disp2dgroup: Vec::new(),
-        },
-        build: Build {
-            uuid: None,
-            item: vec![Item {
-                objectid: 1,
-                transform: None,
-                partnumber: None,
-                path: None,
-                uuid: None,
-            }],
-        },
-    };
+            obj.add_beam_lattice(|bl| {
+                bl.minlength(0.0001)
+                    .radius(1.0)
+                    .ballmode(BallMode::Mixed)
+                    .ballradius(0.25)
+                    .cap(CapMode::Sphere);
+
+                for (v1, v2, r1, r2) in &beam_defs {
+                    bl.add_beam_advanced(*v1, *v2, |b| {
+                        let b = if let Some(radius) = r1 { b.radius_1(*radius) } else { b };
+                        if let Some(radius) = r2 { b.radius_2(*radius) } else { b }
+                    });
+                }
+
+                for (vindex, radius) in &ball_defs {
+                    bl.add_ball_advanced(*vindex, |b| {
+                        if let Some(radius) = radius { b.radius(*radius) } else { b }
+                    });
+                }
+            });
+
+            Ok(())
+        })
+        .unwrap();
+
+    builder.add_build_item(object_id).unwrap();
+    let model = builder.build().unwrap();
 
     let package: ThreemfPackage = model.into();
 

--- a/threemf2/examples/beamlattice_write.rs
+++ b/threemf2/examples/beamlattice_write.rs
@@ -1,5 +1,5 @@
 use threemf2::core::builder::{BallMode, CapMode, ModelBuilder, ObjectType, Unit};
-use threemf2::io::ThreemfPackage;
+use threemf2::io::ThreemfPackageBuilder;
 
 use std::{io::Cursor, vec};
 
@@ -59,14 +59,26 @@ fn main() {
 
                 for (v1, v2, r1, r2) in &beam_defs {
                     bl.add_beam_advanced(*v1, *v2, |b| {
-                        let b = if let Some(radius) = r1 { b.radius_1(*radius) } else { b };
-                        if let Some(radius) = r2 { b.radius_2(*radius) } else { b }
+                        let b = if let Some(radius) = r1 {
+                            b.radius_1(*radius)
+                        } else {
+                            b
+                        };
+                        if let Some(radius) = r2 {
+                            b.radius_2(*radius)
+                        } else {
+                            b
+                        }
                     });
                 }
 
                 for (vindex, radius) in &ball_defs {
                     bl.add_ball_advanced(*vindex, |b| {
-                        if let Some(radius) = radius { b.radius(*radius) } else { b }
+                        if let Some(radius) = radius {
+                            b.radius(*radius)
+                        } else {
+                            b
+                        }
                     });
                 }
             });
@@ -78,7 +90,9 @@ fn main() {
     builder.add_build_item(object_id).unwrap();
     let model = builder.build().unwrap();
 
-    let package: ThreemfPackage = model.into();
+    let mut package_builder = ThreemfPackageBuilder::new();
+    package_builder.set_root_model(model);
+    let package = package_builder.build().expect("Error building package");
 
     let mut bytes: Vec<u8> = vec![];
     let writer = Cursor::new(&mut bytes);

--- a/threemf2/examples/boolean_write.rs
+++ b/threemf2/examples/boolean_write.rs
@@ -5,8 +5,8 @@
 //!
 //! The example creates:
 //! - A cube mesh (base object)
-//! - A sphere mesh (operand)
-//! - A boolean shape that subtracts the sphere from the cube
+//! - A smaller cube mesh (operand)
+//! - A boolean shape that subtracts the smaller cube from the base cube
 //!
 //! # Running the example
 //!
@@ -19,415 +19,99 @@ use std::io::BufWriter;
 
 use threemf2::{
     core::{
-        OptionalResourceId, OptionalResourceIndex,
-        boolean::{Boolean, BooleanOperation, BooleanShape},
-        build::{Build, Item},
-        mesh::{Mesh, Triangle, Triangles, Vertex, Vertices},
-        metadata::Metadata,
-        model::{Model, ThreemfExtensions, Unit},
-        object::{Object, ObjectKind, ObjectType},
+        boolean::BooleanOperation,
+        builder::{ModelBuilder, ObjectType, Unit},
         query::get_model_view,
-        resources::Resources,
     },
     io::ThreemfPackage,
-    threemf_namespaces::ThreemfNamespace,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Creating 3MF file with boolean operations...");
 
-    // Create a simple cube mesh (base object for boolean operation)
-    let cube_mesh_1 = Mesh {
-        vertices: Vertices {
-            vertex: vec![
-                // Bottom face (z = 0)
-                Vertex::new(-5.0, -5.0, 0.0), // 0
-                Vertex::new(5.0, -5.0, 0.0),  // 1
-                Vertex::new(5.0, 5.0, 0.0),   // 2
-                Vertex::new(-5.0, 5.0, 0.0),  // 3
-                // Top face (z = 10)
-                Vertex::new(-5.0, -5.0, 10.0), // 4
-                Vertex::new(5.0, -5.0, 10.0),  // 5
-                Vertex::new(5.0, 5.0, 10.0),   // 6
-                Vertex::new(-5.0, 5.0, 10.0),  // 7
-            ],
-        },
-        triangles: Triangles {
-            triangle: vec![
-                // Bottom face
-                Triangle {
-                    v1: 0,
-                    v2: 1,
-                    v3: 2,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 0,
-                    v2: 2,
-                    v3: 3,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                // Top face
-                Triangle {
-                    v1: 4,
-                    v2: 6,
-                    v3: 5,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 4,
-                    v2: 7,
-                    v3: 6,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                // Front face
-                Triangle {
-                    v1: 0,
-                    v2: 5,
-                    v3: 1,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 0,
-                    v2: 4,
-                    v3: 5,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                // Back face
-                Triangle {
-                    v1: 2,
-                    v2: 7,
-                    v3: 3,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 2,
-                    v2: 6,
-                    v3: 7,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                // Left face
-                Triangle {
-                    v1: 0,
-                    v2: 7,
-                    v3: 4,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 0,
-                    v2: 3,
-                    v3: 7,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                // Right face
-                Triangle {
-                    v1: 1,
-                    v2: 6,
-                    v3: 2,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 1,
-                    v2: 5,
-                    v3: 6,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-            ],
-        },
-        trianglesets: None,
-        beamlattice: None,
-    };
+    let mut builder = ModelBuilder::new(Unit::Millimeter, true);
+    builder
+        .add_metadata("Application", Some("Boolean Example"))
+        .add_metadata("Description", Some("Cube 1 minus Cube 2 using CSG"))
+        .add_build(None)?;
 
-    // Create another cube mesh (operand for boolean operation)
-    let cube_mesh_2 = Mesh {
-        vertices: Vertices {
-            vertex: vec![
-                // Bottom face (z = 3)
-                Vertex::new(-2.0, -2.0, 3.0), // 0
-                Vertex::new(2.0, -2.0, 3.0),  // 1
-                Vertex::new(2.0, 2.0, 3.0),   // 2
-                Vertex::new(-2.0, 2.0, 3.0),  // 3
-                // Top face (z = 7)
-                Vertex::new(-2.0, -2.0, 7.0), // 4
-                Vertex::new(2.0, -2.0, 7.0),  // 5
-                Vertex::new(2.0, 2.0, 7.0),   // 6
-                Vertex::new(-2.0, 2.0, 7.0),  // 7
-            ],
-        },
-        triangles: Triangles {
-            triangle: vec![
-                Triangle {
-                    v1: 0,
-                    v2: 1,
-                    v3: 2,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 0,
-                    v2: 2,
-                    v3: 3,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 4,
-                    v2: 6,
-                    v3: 5,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 4,
-                    v2: 7,
-                    v3: 6,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 0,
-                    v2: 5,
-                    v3: 1,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 0,
-                    v2: 4,
-                    v3: 5,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 2,
-                    v2: 7,
-                    v3: 3,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 2,
-                    v2: 6,
-                    v3: 7,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 0,
-                    v2: 7,
-                    v3: 4,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 0,
-                    v2: 3,
-                    v3: 7,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 1,
-                    v2: 6,
-                    v3: 2,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Triangle {
-                    v1: 1,
-                    v2: 5,
-                    v3: 6,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    p3: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-            ],
-        },
-        trianglesets: None,
-        beamlattice: None,
-    };
+    let cube_triangles: [[usize; 3]; 12] = [
+        [0, 1, 2],
+        [0, 2, 3],
+        [4, 6, 5],
+        [4, 7, 6],
+        [0, 5, 1],
+        [0, 4, 5],
+        [2, 7, 3],
+        [2, 6, 7],
+        [0, 7, 4],
+        [0, 3, 7],
+        [1, 6, 2],
+        [1, 5, 6],
+    ];
 
-    // Create the boolean shape: cube minus sphere (difference operation)
-    let boolean_shape = BooleanShape {
-        objectid: 1, // References cube object
-        operation: BooleanOperation::Difference,
-        transform: None,
-        path: None,
-        booleans: vec![Boolean {
-            objectid: 2, // References sphere object
-            transform: None,
-            path: None,
-        }],
-    };
+    let cube_id = builder.add_mesh_object(|obj| {
+        obj.name("Cube")
+            .object_type(ObjectType::Model)
+            .add_vertices(&[
+                [-5.0, -5.0, 0.0],
+                [5.0, -5.0, 0.0],
+                [5.0, 5.0, 0.0],
+                [-5.0, 5.0, 0.0],
+                [-5.0, -5.0, 10.0],
+                [5.0, -5.0, 10.0],
+                [5.0, 5.0, 10.0],
+                [-5.0, 5.0, 10.0],
+            ]);
 
-    // Create objects
-    let cube_object_1 = Object {
-        id: 1,
-        objecttype: Some(ObjectType::Model),
-        thumbnail: None,
-        partnumber: None,
-        name: Some("Cube".into()),
-        pid: OptionalResourceId::none(),
-        pindex: OptionalResourceIndex::none(),
-        uuid: None,
-        slicestackid: OptionalResourceId::none(),
-        slicepath: None,
-        meshresolution: None,
-        kind: Some(ObjectKind::Mesh(cube_mesh_1)),
-    };
+        obj.add_triangles(&cube_triangles);
+        Ok(())
+    })?;
 
-    let cube_object_2 = Object {
-        id: 2,
-        objecttype: Some(ObjectType::Model),
-        thumbnail: None,
-        partnumber: None,
-        name: Some("Sphere".into()),
-        pid: OptionalResourceId::none(),
-        pindex: OptionalResourceIndex::none(),
-        uuid: None,
-        slicestackid: OptionalResourceId::none(),
-        slicepath: None,
-        meshresolution: None,
-        kind: Some(ObjectKind::Mesh(cube_mesh_2)),
-    };
+    let inner_id = builder.add_mesh_object(|obj| {
+        obj.name("InnerCube")
+            .object_type(ObjectType::Model)
+            .add_vertices(&[
+                [-2.0, -2.0, 3.0],
+                [2.0, -2.0, 3.0],
+                [2.0, 2.0, 3.0],
+                [-2.0, 2.0, 3.0],
+                [-2.0, -2.0, 7.0],
+                [2.0, -2.0, 7.0],
+                [2.0, 2.0, 7.0],
+                [-2.0, 2.0, 7.0],
+            ]);
 
-    let result_object = Object {
-        id: 3,
-        objecttype: Some(ObjectType::Model),
-        thumbnail: None,
-        partnumber: None,
-        name: Some("CubeMinusSphere".into()),
-        pid: OptionalResourceId::none(),
-        pindex: OptionalResourceIndex::none(),
-        uuid: None,
-        slicestackid: OptionalResourceId::none(),
-        slicepath: None,
-        meshresolution: None,
-        kind: Some(ObjectKind::BooleanShape(boolean_shape)),
-    };
+        obj.add_triangles(&cube_triangles);
+        Ok(())
+    })?;
 
-    // Create the model
-    let model = Model {
-        unit: Some(Unit::Millimeter),
-        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Boolean]), // Boolean extension is required
-        recommendedextensions: ThreemfExtensions::default(),
-        metadata: vec![
-            Metadata {
-                name: "Application".into(),
-                preserve: None,
-                value: Some("Boolean Example".into()),
-            },
-            Metadata {
-                name: "Description".into(),
-                preserve: None,
-                value: Some("Cube 1 minus Cube 1 using CSG".into()),
-            },
-        ],
-        resources: Resources {
-            object: vec![cube_object_1, cube_object_2, result_object],
-            basematerials: vec![],
-            slicestack: vec![],
-            colorgroup: Vec::new(),
-            texture2dgroup: Vec::new(),
-            compositematerials: Vec::new(),
-            multiproperties: Vec::new(),
-            texture2d: Vec::new(),
-            displacement2d: Vec::new(),
-            normvectorgroup: Vec::new(),
-            disp2dgroup: Vec::new(),
-        },
-        build: Build {
-            uuid: None,
-            item: vec![Item {
-                objectid: 3, // Build the boolean result
-                transform: None,
-                partnumber: None,
-                path: None,
-                uuid: None,
-            }],
-        },
-    };
+    let result_id = builder.add_booleanshape_object(|obj| {
+        obj.name("CubeMinusCube");
+        obj.base_object(cube_id, BooleanOperation::Difference);
+        obj.add_boolean(inner_id);
+        Ok(())
+    })?;
 
-    println!("  Created cube mesh 1 (object id: 1)");
-    println!("  Created cube mesh 2 (object id: 2)");
-    println!("  Created boolean shape: cube 1 - cube 2 (object id: 3)");
+    builder.add_build_item(result_id)?;
+
+    println!("  Created cube mesh (object id: {})", cube_id.0);
+    println!("  Created inner cube mesh (object id: {})", inner_id.0);
+    println!("  Created boolean shape (object id: {})", result_id.0);
     println!("  Added boolean result to build plate");
+
+    let model = builder.build()?;
 
     println!("\nModel statistics:");
     let model_view = get_model_view(&model);
     println!("  Objects: {}", model_view.object_count());
     println!("  Build items: {}", model_view.build_item_count());
-    println!(
-        "  Required extensions: {:?}",
-        model_view.required_extensions()
-    );
+    println!("  Required extensions: {:?}", model_view.required_extensions());
 
-    // Create 3MF package and write to file
     let package: ThreemfPackage = model.into();
-
     let output_path = "boolean_example.3mf";
     let file = File::create(output_path)?;
     let writer = BufWriter::new(file);
-
     package.write(writer)?;
 
     println!("\nSuccessfully wrote 3MF file: {}", output_path);

--- a/threemf2/examples/boolean_write.rs
+++ b/threemf2/examples/boolean_write.rs
@@ -14,8 +14,7 @@
 //! cargo run --example boolean_write --features "io-write"
 //! ```
 
-use std::fs::File;
-use std::io::BufWriter;
+use std::io::Cursor;
 
 use threemf2::{
     core::{
@@ -23,7 +22,7 @@ use threemf2::{
         builder::{ModelBuilder, ObjectType, Unit},
         query::get_model_view,
     },
-    io::ThreemfPackage,
+    io::ThreemfPackageBuilder,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -106,15 +105,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let model_view = get_model_view(&model);
     println!("  Objects: {}", model_view.object_count());
     println!("  Build items: {}", model_view.build_item_count());
-    println!("  Required extensions: {:?}", model_view.required_extensions());
+    println!(
+        "  Required extensions: {:?}",
+        model_view.required_extensions()
+    );
 
-    let package: ThreemfPackage = model.into();
-    let output_path = "boolean_example.3mf";
-    let file = File::create(output_path)?;
-    let writer = BufWriter::new(file);
-    package.write(writer)?;
+    let mut package_builder = ThreemfPackageBuilder::new();
+    package_builder.set_root_model(model);
+    let package = package_builder.build().expect("Error building package");
+    let mut buffer = Cursor::new(Vec::new());
+    package.write(&mut buffer)?;
 
-    println!("\nSuccessfully wrote 3MF file: {}", output_path);
+    println!(
+        "\nSuccessfully wrote 3MF data to buffer: {} bytes",
+        buffer.get_ref().len()
+    );
     println!("\nNote: This example uses simple cubes to approximate geometry.");
 
     Ok(())

--- a/threemf2/examples/builder_example.rs
+++ b/threemf2/examples/builder_example.rs
@@ -2,7 +2,7 @@ use threemf2::core::{
     builder::{ModelBuilder, ObjectType, Unit},
     query::{get_mesh_objects_from_model, get_model_view, get_objects_from_model},
 };
-use threemf2::io::ThreemfPackage;
+use threemf2::io::ThreemfPackageBuilder;
 
 /// This example shows how to build 3MF Model using ModelBuilder.
 /// Use this to reduce the boilerplate needed to setup 3MF Models.
@@ -95,8 +95,10 @@ fn main() {
                 println!("Triangles: {}", mesh.triangle_count());
             }
 
-            //to create a 3MF Package easily just convert model into a package
-            let _: ThreemfPackage = model.into();
+            //to create a 3MF Package easily use the package builder
+            let mut package_builder = ThreemfPackageBuilder::new();
+            package_builder.set_root_model(model);
+            let _package = package_builder.build().expect("Error building package");
         }
         Err(err) => panic!("{err:?}"),
     }

--- a/threemf2/examples/core-no-default-features.rs
+++ b/threemf2/examples/core-no-default-features.rs
@@ -1,16 +1,7 @@
 use threemf2::core::{
-    OptionalResourceId,
-    build::{Build, Item},
-    mesh::{Mesh, Triangle, Triangles, Vertex, Vertices},
-    metadata::Metadata,
-    model::{Model, ThreemfExtensions, Unit},
-    object::{Object, ObjectKind, ObjectType},
+    builder::{ModelBuilder, ObjectType, Unit},
     query::get_model_view,
-    resources::Resources,
-    types::OptionalResourceIndex,
 };
-
-use std::vec;
 
 /// This is an example showing the core 3MF Types available without any default features.
 /// With no default features only the core structs are available from this library.
@@ -18,73 +9,23 @@ use std::vec;
 /// `cargo run --example core-no-default-features --no-default-features`
 ///
 fn main() {
-    let model = Model {
-        unit: Some(Unit::Inch),
-        requiredextensions: ThreemfExtensions::default(),
-        recommendedextensions: ThreemfExtensions::default(),
-        metadata: vec![Metadata {
-            name: "Test metadata".into(),
-            preserve: None,
-            value: None,
-        }],
-        resources: Resources {
-            object: vec![Object {
-                id: 1,
-                objecttype: Some(ObjectType::Model),
-                thumbnail: None,
-                partnumber: None,
-                name: None,
-                pid: OptionalResourceId::none(),
-                pindex: OptionalResourceIndex::none(),
-                uuid: None,
-                slicestackid: OptionalResourceId::none(),
-                slicepath: None,
-                meshresolution: None,
-                kind: Some(ObjectKind::Mesh(Mesh {
-                    vertices: Vertices {
-                        vertex: vec![
-                            Vertex::new(0.0, 0.0, 0.0),
-                            Vertex::new(-1.0, 0.0, 0.0),
-                            Vertex::new(-1.0, 1.0, 0.0),
-                        ],
-                    },
-                    triangles: Triangles {
-                        triangle: vec![Triangle {
-                            v1: 0,
-                            v2: 2,
-                            v3: 3,
-                            p1: OptionalResourceIndex::none(),
-                            p2: OptionalResourceIndex::none(),
-                            p3: OptionalResourceIndex::none(),
-                            pid: OptionalResourceId::none(),
-                        }],
-                    },
-                    trianglesets: None,
-                    beamlattice: None,
-                })),
-            }],
-            basematerials: vec![],
-            slicestack: vec![],
-            colorgroup: Vec::new(),
-            texture2dgroup: Vec::new(),
-            compositematerials: Vec::new(),
-            multiproperties: Vec::new(),
-            texture2d: Vec::new(),
-            displacement2d: Vec::new(),
-            normvectorgroup: Vec::new(),
-            disp2dgroup: Vec::new(),
-        },
-        build: Build {
-            uuid: None,
-            item: vec![Item {
-                objectid: 1,
-                transform: None,
-                partnumber: None,
-                path: None,
-                uuid: None,
-            }],
-        },
-    };
+    let mut builder = ModelBuilder::new(Unit::Inch, true);
+    builder
+        .add_metadata("Test metadata", None)
+        .add_build(None)
+        .unwrap();
+
+    let obj_id = builder
+        .add_mesh_object(|obj| {
+            obj.object_type(ObjectType::Model);
+            obj.add_vertices(&[[0.0, 0.0, 0.0], [-1.0, 0.0, 0.0], [-1.0, 1.0, 0.0]]);
+            obj.add_triangle(&[0, 1, 2]);
+            Ok(())
+        })
+        .unwrap();
+
+    builder.add_build_item(obj_id).unwrap();
+    let model = builder.build().unwrap();
 
     println!(
         "Number of build items: {}",

--- a/threemf2/examples/io_memory_optimized_read.rs
+++ b/threemf2/examples/io_memory_optimized_read.rs
@@ -8,7 +8,8 @@ use std::{fs::File, path::PathBuf};
 /// Note: io_memory-optimized-read is part of the default features also
 ///
 fn main() {
-    let path = PathBuf::from("./tests/data/third-party/mgx-core-prod-beamlattice-material.3mf");
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/data/mgx-core-prod-beamlattice-material-displacement-mesh.3mf");
     let reader = File::open(path).unwrap();
 
     let result = ThreemfPackage::from_reader_with_memory_optimized_deserializer(reader, true);

--- a/threemf2/examples/io_speed_optimized_read.rs
+++ b/threemf2/examples/io_speed_optimized_read.rs
@@ -7,7 +7,8 @@ use std::{fs::File, path::PathBuf};
 /// `cargo run --example io_speed_optimized_read --features io-speed-optimized-read`
 ///
 fn main() {
-    let path = PathBuf::from("./tests/data/third-party/mgx-core-prod-beamlattice-material.3mf");
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/data/mgx-core-prod-beamlattice-material-displacement-mesh.3mf");
     let reader = File::open(path).unwrap();
 
     let result = ThreemfPackage::from_reader_with_speed_optimized_deserializer(reader, true);

--- a/threemf2/examples/query_example.rs
+++ b/threemf2/examples/query_example.rs
@@ -19,7 +19,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== 3MF Query API Example ===\n");
 
     // Load a test package with multiple models
-    let path = PathBuf::from("tests/data/mesh-composedpart-beamlattice-separate-model-files.3mf");
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/data/mesh-composedpart-beamlattice-separate-model-files.3mf");
     let file = File::open(&path)?;
     let package = ThreemfPackage::from_reader_with_memory_optimized_deserializer(file, true)?;
 

--- a/threemf2/examples/slice_write.rs
+++ b/threemf2/examples/slice_write.rs
@@ -3,15 +3,10 @@ use threemf2::{
         builder::{ModelBuilder, ObjectType, Unit},
         slice::MeshResolution,
     },
-    io::{
-        ThreemfPackage,
-        content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
-        relationship::{Relationship, RelationshipType, Relationships},
-    },
+    io::ThreemfPackageBuilder,
 };
 
-use std::collections::HashMap;
-use std::{io::Cursor, vec};
+use std::io::Cursor;
 
 /// This example shows how to create and write a 3MF file with slice extension data.
 /// This demonstrates the Slice Extension support in threemf2.
@@ -78,38 +73,9 @@ fn main() {
     builder.add_build_item(object_id).unwrap();
     let model = builder.build().unwrap();
 
-    let content_types = ContentTypes {
-        defaults: vec![
-            DefaultContentTypes {
-                extension: "rels".to_owned(),
-                content_type: DefaultContentTypeEnum::Relationship,
-            },
-            DefaultContentTypes {
-                extension: "model".to_owned(),
-                content_type: DefaultContentTypeEnum::Model,
-            },
-        ],
-    };
-
-    let relationships = HashMap::from([(
-        "_rels/.rels".to_owned(),
-        Relationships {
-            relationships: vec![Relationship {
-                id: "rel0".to_owned(),
-                target: "3D/3Dmodel.model".to_owned(),
-                relationship_type: RelationshipType::Model,
-            }],
-        },
-    )]);
-
-    let package = ThreemfPackage::new(
-        model,
-        HashMap::new(),
-        HashMap::new(),
-        HashMap::new(),
-        relationships,
-        content_types,
-    );
+    let mut package_builder = ThreemfPackageBuilder::new();
+    package_builder.set_root_model(model);
+    let package = package_builder.build().expect("Error building package");
 
     let mut buf = Cursor::new(Vec::new());
     package.write(&mut buf).expect("Error writing 3MF package");

--- a/threemf2/examples/slice_write.rs
+++ b/threemf2/examples/slice_write.rs
@@ -1,19 +1,13 @@
 use threemf2::{
     core::{
-        OptionalResourceId, OptionalResourceIndex,
-        build::{Build, Item},
-        mesh::{self, Mesh, Triangle, Triangles, Vertices},
-        model::{Model, ThreemfExtensions, Unit},
-        object::{Object, ObjectKind, ObjectType},
-        resources::Resources,
-        slice::{self, MeshResolution, Polygon, Segment, Slice, SliceStack},
+        builder::{ModelBuilder, ObjectType, Unit},
+        slice::MeshResolution,
     },
     io::{
         ThreemfPackage,
         content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
         relationship::{Relationship, RelationshipType, Relationships},
     },
-    threemf_namespaces::ThreemfNamespace,
 };
 
 use std::collections::HashMap;
@@ -26,233 +20,64 @@ use std::{io::Cursor, vec};
 /// `cargo run --example slice_write --no-default-features --features io-write`
 ///
 fn main() {
-    // Create vertices for a simple cube mesh
-    let vertices = Vertices {
-        vertex: vec![
-            mesh::Vertex::new(0.0, 0.0, 0.0),
-            mesh::Vertex::new(10.0, 0.0, 0.0),
-            mesh::Vertex::new(10.0, 10.0, 0.0),
-            mesh::Vertex::new(0.0, 10.0, 0.0),
-            mesh::Vertex::new(0.0, 0.0, 10.0),
-            mesh::Vertex::new(10.0, 0.0, 10.0),
-            mesh::Vertex::new(10.0, 10.0, 10.0),
-            mesh::Vertex::new(0.0, 10.0, 10.0),
-        ],
-    };
+    let mut builder = ModelBuilder::new(Unit::Millimeter, true);
+    builder.add_build(None).unwrap();
 
-    // Create triangles for the mesh
-    let triangles = Triangles {
-        triangle: vec![
-            // Bottom face
-            Triangle {
-                v1: 0,
-                v2: 2,
-                v3: 1,
-                p1: OptionalResourceIndex::none(),
-                p2: OptionalResourceIndex::none(),
-                p3: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-            },
-            Triangle {
-                v1: 0,
-                v2: 3,
-                v3: 2,
-                p1: OptionalResourceIndex::none(),
-                p2: OptionalResourceIndex::none(),
-                p3: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-            },
-            // Top face
-            Triangle {
-                v1: 4,
-                v2: 5,
-                v3: 6,
-                p1: OptionalResourceIndex::none(),
-                p2: OptionalResourceIndex::none(),
-                p3: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-            },
-            Triangle {
-                v1: 4,
-                v2: 6,
-                v3: 7,
-                p1: OptionalResourceIndex::none(),
-                p2: OptionalResourceIndex::none(),
-                p3: OptionalResourceIndex::none(),
-                pid: OptionalResourceId::none(),
-            },
-        ],
-    };
+    let slicestack_id = builder
+        .add_slice_stack(|stack| {
+            stack.zbottom(0.0);
 
-    // Create slice vertices for the first layer
-    let slice_vertices_1 = slice::Vertices {
-        vertex: vec![
-            slice::Vertex {
-                x: 0.0.into(),
-                y: 0.0.into(),
-            },
-            slice::Vertex {
-                x: 10.0.into(),
-                y: 0.0.into(),
-            },
-            slice::Vertex {
-                x: 10.0.into(),
-                y: 10.0.into(),
-            },
-            slice::Vertex {
-                x: 0.0.into(),
-                y: 10.0.into(),
-            },
-        ],
-    };
+            stack.add_slice(|slice| {
+                slice.ztop(0.1);
+                slice.add_vertices(&[(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]);
+                slice.add_polygon(|poly| {
+                    poly.start_vertex(0);
+                    poly.add_segment(1);
+                    poly.add_segment(2);
+                    poly.add_segment(3);
+                });
+            });
 
-    // Create first slice at z=0.1
-    let slice_1 = Slice {
-        ztop: 0.1.into(),
-        vertices: Some(slice_vertices_1),
-        polygon: vec![Polygon {
-            startv: 0,
-            segment: vec![
-                Segment {
-                    v2: 1,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Segment {
-                    v2: 2,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Segment {
-                    v2: 3,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-            ],
-        }],
-    };
+            stack.add_slice(|slice| {
+                slice.ztop(0.2);
+                slice.add_vertices(&[(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]);
+                slice.add_polygon(|poly| {
+                    poly.start_vertex(0);
+                    poly.add_segment(1);
+                    poly.add_segment(2);
+                    poly.add_segment(3);
+                });
+            });
+        })
+        .unwrap();
 
-    // Create slice vertices for the second layer
-    let slice_vertices_2 = slice::Vertices {
-        vertex: vec![
-            slice::Vertex {
-                x: 0.0.into(),
-                y: 0.0.into(),
-            },
-            slice::Vertex {
-                x: 10.0.into(),
-                y: 0.0.into(),
-            },
-            slice::Vertex {
-                x: 10.0.into(),
-                y: 10.0.into(),
-            },
-            slice::Vertex {
-                x: 0.0.into(),
-                y: 10.0.into(),
-            },
-        ],
-    };
+    let object_id = builder
+        .add_mesh_object(|obj| {
+            obj.object_type(ObjectType::Model)
+                .part_number("SLICE_EXAMPLE_001")
+                .name("SlicedCube")
+                .slice_stack(slicestack_id, None, Some(MeshResolution::LowRes));
 
-    // Create second slice at z=0.2
-    let slice_2 = Slice {
-        ztop: 0.2.into(),
-        vertices: Some(slice_vertices_2),
-        polygon: vec![Polygon {
-            startv: 0,
-            segment: vec![
-                Segment {
-                    v2: 1,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Segment {
-                    v2: 2,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-                Segment {
-                    v2: 3,
-                    p1: OptionalResourceIndex::none(),
-                    p2: OptionalResourceIndex::none(),
-                    pid: OptionalResourceId::none(),
-                },
-            ],
-        }],
-    };
+            obj.add_vertices(&[
+                [0.0, 0.0, 0.0],
+                [10.0, 0.0, 0.0],
+                [10.0, 10.0, 0.0],
+                [0.0, 10.0, 0.0],
+                [0.0, 0.0, 10.0],
+                [10.0, 0.0, 10.0],
+                [10.0, 10.0, 10.0],
+                [0.0, 10.0, 10.0],
+            ]);
 
-    // Create the slice stack
-    let slicestack = SliceStack {
-        id: 1,
-        zbottom: Some(0.0.into()),
-        slice: vec![slice_1, slice_2],
-        sliceref: vec![],
-    };
+            obj.add_triangles(&[[0, 2, 1], [0, 3, 2], [4, 5, 6], [4, 6, 7]]);
 
-    // Create the object with mesh and slice reference
-    let object = Object {
-        id: 1,
-        objecttype: Some(ObjectType::Model),
-        thumbnail: None,
-        partnumber: Some("SLICE_EXAMPLE_001".into()),
-        name: Some("SlicedCube".into()),
-        pid: OptionalResourceId::none(),
-        pindex: OptionalResourceIndex::none(),
-        uuid: None,
-        slicestackid: OptionalResourceId::new(1), // References slice stack with id=1
-        slicepath: None,                          // Slice stack is in the same file
-        meshresolution: Some(MeshResolution::LowRes), // Mesh is low resolution
-        kind: Some(ObjectKind::Mesh(Mesh {
-            vertices,
-            triangles,
-            trianglesets: None,
-            beamlattice: None,
-        })),
-    };
+            Ok(())
+        })
+        .unwrap();
 
-    // Create resources
-    let resources = Resources {
-        object: vec![object],
-        basematerials: vec![],
-        slicestack: vec![slicestack],
-        colorgroup: Vec::new(),
-        texture2dgroup: Vec::new(),
-        compositematerials: Vec::new(),
-        multiproperties: Vec::new(),
-        texture2d: Vec::new(),
-        displacement2d: Vec::new(),
-        normvectorgroup: Vec::new(),
-        disp2dgroup: Vec::new(),
-    };
+    builder.add_build_item(object_id).unwrap();
+    let model = builder.build().unwrap();
 
-    // Create build section
-    let build = Build {
-        uuid: None,
-        item: vec![Item {
-            objectid: 1,
-            transform: None,
-            partnumber: None,
-            path: None,
-            uuid: None,
-        }],
-    };
-
-    // Create the model
-    let model = Model {
-        unit: Some(Unit::Millimeter),
-        requiredextensions: ThreemfExtensions::new(&[ThreemfNamespace::Slice]), // Slice extension is required
-        recommendedextensions: ThreemfExtensions::default(),
-        metadata: vec![],
-        resources,
-        build,
-    };
-
-    // Create content types
     let content_types = ContentTypes {
         defaults: vec![
             DefaultContentTypes {
@@ -266,7 +91,6 @@ fn main() {
         ],
     };
 
-    // Create relationships
     let relationships = HashMap::from([(
         "_rels/.rels".to_owned(),
         Relationships {
@@ -278,7 +102,6 @@ fn main() {
         },
     )]);
 
-    // Create the package
     let package = ThreemfPackage::new(
         model,
         HashMap::new(),
@@ -288,7 +111,6 @@ fn main() {
         content_types,
     );
 
-    // Write to buffer (in real usage, this would be a file)
     let mut buf = Cursor::new(Vec::new());
     package.write(&mut buf).expect("Error writing 3MF package");
 

--- a/threemf2/examples/string_extraction.rs
+++ b/threemf2/examples/string_extraction.rs
@@ -1,5 +1,8 @@
 use std::{fs::File, path::PathBuf};
-use threemf2::io::{CachePolicy, Error, ThreemfPackageLazyReader};
+use threemf2::{
+    core::PathResource,
+    io::{CachePolicy, Error, ThreemfPackageLazyReader},
+};
 
 /// This example demonstrates extracting raw XML strings from a 3MF package
 /// using the pull-based reader with string extraction methods.
@@ -27,7 +30,7 @@ fn main() {
 
     println!("2. Root Relationships XML:");
     package
-        .with_relationships_xml("_rels/.rels", |xml| {
+        .with_relationships_xml(&PathResource::new("_rels/.rels", true).unwrap(), |xml| {
             println!("{}\n", xml);
         })
         .unwrap();
@@ -41,20 +44,29 @@ fn main() {
 
     println!("4. Sub-model XML (first 200 chars):");
     package
-        .with_model_xml("/3D/midway.model", |xml| {
-            println!("{}...\n", &xml[..xml.len().min(200)]);
-        })
+        .with_model_xml(
+            &PathResource::new("/3D/midway.model", true).unwrap(),
+            |xml| {
+                println!("{}...\n", &xml[..xml.len().min(200)]);
+            },
+        )
         .unwrap();
 
     // Show that invalid paths return errors
     println!("5. Invalid path handling:");
-    match package.with_model_xml("/invalid/path.model", |_| "found") {
+    match package.with_model_xml(
+        &PathResource::new("/invalid/path.model", true).unwrap(),
+        |_| "found",
+    ) {
         Ok(result) => println!("Unexpected success: {}", result),
         Err(Error::ResourceNotFound(msg)) => println!("Model not found: {}\n", msg),
         Err(other) => println!("Other error: {:?}\n", other),
     }
 
-    match package.with_relationships_xml("/invalid/rels.xml", |_| "found") {
+    match package.with_relationships_xml(
+        &PathResource::new("/invalid/rels.xml", true).unwrap(),
+        |_| "found",
+    ) {
         Ok(result) => println!("Unexpected success: {}", result),
         Err(Error::ResourceNotFound(msg)) => println!("Relationships not found: {}\n", msg),
         Err(other) => println!("Other error: {:?}\n", other),

--- a/threemf2/examples/string_extraction.rs
+++ b/threemf2/examples/string_extraction.rs
@@ -7,7 +7,7 @@ use threemf2::io::{CachePolicy, Error, ThreemfPackageLazyReader};
 /// Run with:
 /// `cargo run --example string_extraction --features io-lazy-read`
 fn main() {
-    let path = PathBuf::from("./tests/data/third-party/P_XPX_0702_02.3mf");
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data/P_XPX_0702_02.3mf");
     let reader = File::open(path).unwrap();
 
     let package = ThreemfPackageLazyReader::from_reader_with_memory_optimized_deserializer(

--- a/threemf2/examples/unpack.rs
+++ b/threemf2/examples/unpack.rs
@@ -11,7 +11,8 @@ use std::{fs::File, path::PathBuf};
 /// `cargo run --example unpack --no-default-features --features io-lazy-read`
 ///
 fn main() {
-    let path = PathBuf::from("./tests/data/mesh-composedpart-separate-model-files.3mf");
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/data/mesh-composedpart-separate-model-files.3mf");
     let reader = File::open(path).unwrap();
 
     let result = ThreemfPackageLazyReader::from_reader_with_memory_optimized_deserializer(

--- a/threemf2/examples/write.rs
+++ b/threemf2/examples/write.rs
@@ -1,16 +1,5 @@
-use threemf2::{
-    core::{
-        OptionalResourceId,
-        build::{Build, Item},
-        mesh::*,
-        metadata::Metadata,
-        model::{Model, ThreemfExtensions, Unit},
-        object::{Object, ObjectKind, ObjectType},
-        resources::Resources,
-        types::OptionalResourceIndex,
-    },
-    io::ThreemfPackage,
-};
+use threemf2::core::builder::{ModelBuilder, ObjectType, Unit};
+use threemf2::io::ThreemfPackage;
 
 use std::{io::Cursor, vec};
 
@@ -20,74 +9,24 @@ use std::{io::Cursor, vec};
 /// `cargo run --example write --no-default-features --features io-write`
 ///
 fn main() {
-    let model = Model {
-        unit: Some(Unit::Inch),
-        requiredextensions: ThreemfExtensions::default(),
-        recommendedextensions: ThreemfExtensions::default(),
-        metadata: vec![Metadata {
-            name: "Test metadata".into(),
-            preserve: None,
-            value: None,
-        }],
-        resources: Resources {
-            object: vec![Object {
-                id: 1,
-                objecttype: Some(ObjectType::Model),
-                thumbnail: None,
-                partnumber: None,
-                name: None,
-                pid: OptionalResourceId::none(),
-                pindex: OptionalResourceIndex::none(),
-                uuid: None,
-                slicestackid: OptionalResourceId::none(),
-                slicepath: None,
-                meshresolution: None,
-                kind: Some(ObjectKind::Mesh(Mesh {
-                    vertices: Vertices {
-                        vertex: vec![
-                            Vertex::new(0.0, 0.0, 0.0),
-                            Vertex::new(-1.0, 0.0, 0.0),
-                            Vertex::new(-1.0, 1.0, 0.0),
-                        ],
-                    },
-                    triangles: Triangles {
-                        triangle: vec![Triangle {
-                            v1: 0,
-                            v2: 1,
-                            v3: 2,
-                            p1: OptionalResourceIndex::none(),
-                            p2: OptionalResourceIndex::none(),
-                            p3: OptionalResourceIndex::none(),
-                            pid: OptionalResourceId::none(),
-                        }],
-                    },
-                    trianglesets: None,
-                    beamlattice: None,
-                })),
-            }],
-            basematerials: vec![],
-            slicestack: vec![],
-            colorgroup: Vec::new(),
-            texture2dgroup: Vec::new(),
-            compositematerials: Vec::new(),
-            multiproperties: Vec::new(),
-            texture2d: Vec::new(),
-            displacement2d: Vec::new(),
-            normvectorgroup: Vec::new(),
-            disp2dgroup: Vec::new(),
-        },
-        build: Build {
-            uuid: None,
-            item: vec![Item {
-                objectid: 1,
-                transform: None,
-                partnumber: None,
-                path: None,
-                uuid: None,
-            }],
-        },
-    };
+    let mut builder = ModelBuilder::new(Unit::Inch, true);
+    builder
+        .add_metadata("Test metadata", None)
+        .add_build(None)
+        .unwrap();
 
+    let obj_id = builder
+        .add_mesh_object(|obj| {
+            obj.object_type(ObjectType::Model);
+            obj.add_vertices(&[[0.0, 0.0, 0.0], [-1.0, 0.0, 0.0], [-1.0, 1.0, 0.0]]);
+            obj.add_triangle(&[0, 1, 2]);
+            Ok(())
+        })
+        .unwrap();
+
+    builder.add_build_item(obj_id).unwrap();
+
+    let model = builder.build().unwrap();
     let package: ThreemfPackage = model.into();
 
     let mut bytes: Vec<u8> = vec![];

--- a/threemf2/examples/write.rs
+++ b/threemf2/examples/write.rs
@@ -1,5 +1,5 @@
 use threemf2::core::builder::{ModelBuilder, ObjectType, Unit};
-use threemf2::io::ThreemfPackage;
+use threemf2::io::ThreemfPackageBuilder;
 
 use std::{io::Cursor, vec};
 
@@ -27,7 +27,9 @@ fn main() {
     builder.add_build_item(obj_id).unwrap();
 
     let model = builder.build().unwrap();
-    let package: ThreemfPackage = model.into();
+    let mut package_builder = ThreemfPackageBuilder::new();
+    package_builder.set_root_model(model);
+    let package = package_builder.build().expect("Error building package");
 
     let mut bytes: Vec<u8> = vec![];
     let writer = Cursor::new(&mut bytes);

--- a/threemf2/src/core/builder.rs
+++ b/threemf2/src/core/builder.rs
@@ -16,75 +16,6 @@
 //! - [`BuildBuilder`] - Configures the build section (what gets printed)
 //! - [`TriangleSetsBuilder`] - Organizes triangles into named groups
 //!
-//! # Basic Usage
-//!
-//! ```rust,ignore
-//! use threemf2::io::builder::{ModelBuilder, Unit};
-//!
-//! // Create a root model
-//! let mut builder = ModelBuilder::new(Unit::Millimeter, true);
-//! builder.add_metadata("Application", Some("MyApp"));
-//!
-//! // Add a build section
-//! builder.add_build(None)?;
-//!
-//! // Add a mesh object
-//! let cube_id = builder.add_mesh_object(|obj| {
-//!     obj.name("Cube");
-//!     obj.add_vertices(&[
-//!         [0.0, 0.0, 0.0],
-//!         [10.0, 0.0, 0.0],
-//!         [10.0, 10.0, 0.0],
-//!         [0.0, 10.0, 0.0],
-//!     ]);
-//!     obj.add_triangles(&[
-//!         [0, 1, 2],
-//!         [0, 2, 3],
-//!     ]);
-//!     Ok(())
-//! })?;
-//!
-//! // Add to build plate
-//! builder.add_build_item(cube_id)?;
-//!
-//! // Build the final model
-//! let model = builder.build()?;
-//! ```
-//!
-//! # Boolean Operations Example
-//!
-//! ```rust,ignore
-//! use threemf2::io::builder::{ModelBuilder, Unit, BooleanOperation};
-//!
-//! let mut builder = ModelBuilder::new(Unit::Millimeter, true);
-//! builder.add_build(None)?;
-//!
-//! // Create base mesh (cube)
-//! let cube_id = builder.add_mesh_object(|obj| {
-//!     obj.name("Cube");
-//!     // ... add cube geometry
-//!     Ok(())
-//! })?;
-//!
-//! // Create sphere mesh
-//! let sphere_id = builder.add_mesh_object(|obj| {
-//!     obj.name("Sphere");
-//!     // ... add sphere geometry
-//!     Ok(())
-//! })?;
-//!
-//! // Create a boolean shape (cube minus sphere)
-//! let result_id = builder.add_booleanshape_object(|obj| {
-//!     obj.name("CubeMinusSphere");
-//!     obj.base_object(cube_id, BooleanOperation::Difference);
-//!     obj.add_boolean(sphere_id);
-//!     Ok(())
-//! })?;
-//!
-//! builder.add_build_item(result_id)?;
-//! let model = builder.build()?;
-//! ```
-//!
 //! # Root vs Sub-Models
 //!
 //! 3MF models can be either root models or sub-models:
@@ -125,26 +56,32 @@ use crate::{
         boolean::{Boolean as BooleanOp, BooleanOperation, BooleanShape},
         build::{Build, Item},
         component::{Component, Components},
+        displacement::{
+            self, Disp2DGroup, Displacement2D, DisplacementMesh, NormVector, NormVectorGroup,
+        },
+        material::{
+            self, ColorGroup, CompositeMaterials, MultiProperties, Texture2D, Texture2DGroup,
+        },
         mesh::{Mesh, Triangle, Triangles, Vertex, Vertices},
         metadata::Metadata,
         model::{Model, ThreemfExtensions},
         object::{Object, ObjectKind},
-        resources::Resources,
+        resources::{Base, BaseMaterials, Resources},
         slice::{self, MeshResolution, Polygon, Segment, Slice, SliceRef, SliceStack},
         transform::Transform,
     },
     threemf_namespaces::ThreemfNamespace,
 };
 
-use std::ops::{Deref, DerefMut};
-
 pub use crate::core::beamlattice::{BallMode, CapMode, ClippingMode};
 pub use crate::core::model::Unit;
 pub use crate::core::object::ObjectType;
 use crate::core::types::{
-    OptionalResourceId, OptionalResourceIndex, PathResource, ResourceId, ResourceIndex,
-    UuidResource,
+    OptionalResourceId, OptionalResourceIndex, PathResource, ResourceId, ResourceIdCollection,
+    ResourceIndex, ResourceIndexCollection, StrResource, UuidResource,
 };
+
+use std::ops::{Deref, DerefMut};
 
 /// Errors that can occur when building a [`Model`].
 ///
@@ -233,90 +170,6 @@ pub enum ProductionExtensionError {
 ///   model file in a 3MF package (typically `/3D/3dmodel.model`).
 /// - **Sub-models** (`is_root = false`): Cannot have a Build section. These are auxiliary
 ///   models referenced by the root model or other sub-models.
-///
-/// # Examples
-///
-/// ## Creating a simple root model with a mesh object
-///
-/// ```rust,ignore
-/// use threemf2::io::builder::{ModelBuilder, Unit, ObjectType};
-///
-/// let mut builder = ModelBuilder::new(Unit::Millimeter, true);
-///
-/// // Add metadata
-/// builder.add_metadata("Application", Some("MyApp"));
-///
-/// // Create build section
-/// builder.add_build(None)?;
-///
-/// // Add a cube mesh object
-/// let cube_id = builder.add_mesh_object(|obj| {
-///     obj.name("Cube")
-///        .object_type(ObjectType::Model);
-///
-///     // Add vertices
-///     obj.add_vertices(&[
-///         [0.0, 0.0, 0.0],
-///         [10.0, 0.0, 0.0],
-///         [10.0, 10.0, 0.0],
-///         [0.0, 10.0, 0.0],
-///     ]);
-///
-///     // Add triangles
-///     obj.add_triangles(&[[0, 1, 2], [0, 2, 3]]);
-///
-///     Ok(())
-/// })?;
-///
-/// // Add object to build plate
-/// builder.add_build_item(cube_id)?;
-///
-/// // Build the final model
-/// let model = builder.build()?;
-/// ```
-///
-/// ## Creating a sub-model
-///
-/// ```rust,ignore
-/// // Sub-models cannot have a build section
-/// let mut builder = ModelBuilder::new(Unit::Millimeter, false);
-///
-/// let obj_id = builder.add_mesh_object(|obj| {
-///     obj.name("SubModelPart");
-///     obj.add_vertex(&[0.0, 0.0, 0.0]);
-///     obj.add_vertex(&[1.0, 0.0, 0.0]);
-///     obj.add_vertex(&[0.0, 1.0, 0.0]);
-///     obj.add_triangle(&[0, 1, 2]);
-///     Ok(())
-/// })?;
-///
-/// let model = builder.build()?;
-/// ```
-///
-/// ## Using the Production extension
-///
-/// ```rust,ignore
-/// let mut builder = ModelBuilder::new(Unit::Millimeter, true);
-///
-/// // Enable Production extension - requires UUIDs on all objects and items
-/// builder.make_production_extension_required()?;
-///
-/// builder.add_build(Some(UuidResource::from("build-uuid-12345")))?;
-///
-/// let obj_id = builder.add_mesh_object(|obj| {
-///     obj.name("TrackedPart")
-///        .uuid("object-uuid-67890");  // UUID required!
-///     obj.add_vertex(&[0.0, 0.0, 0.0]);
-///     obj.add_triangle(&[0, 1, 2]);
-///     Ok(())
-/// })?;
-///
-/// builder.add_build_item_advanced(obj_id, |item| {
-///     item.uuid("item-uuid-abcdef");  // UUID required!
-/// })?;
-///
-/// let model = builder.build()?;
-/// ```
 pub struct ModelBuilder {
     unit: Option<Unit>,
     requiredextensions: Vec<ThreemfNamespace>,
@@ -336,6 +189,19 @@ pub struct ModelBuilder {
     // tracks next slicestack id
     next_slicestack_id: SliceStackId,
 
+    // tracks next material resource ids
+    next_colorgroup_id: ResourceId,
+    next_texture2dgroup_id: ResourceId,
+    next_texture2d_id: ResourceId,
+    next_composite_materials_id: ResourceId,
+    next_multi_properties_id: ResourceId,
+    next_basematerials_id: ResourceId,
+
+    // tracks next displacement resource ids
+    next_displacement2d_id: ResourceId,
+    next_normvectorgroup_id: ResourceId,
+    next_disp2dgroup_id: ResourceId,
+
     // tracks if the model requires production ext
     // ensures UUID is set at the minimum
     is_production_ext_required: bool,
@@ -350,16 +216,6 @@ impl ModelBuilder {
     /// - `is_root`: Whether this is a root model (`true`) or sub-model (`false`)
     ///
     /// Root models must have a Build section, while sub-models cannot have one.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// // Create a root model in millimeters
-    /// let builder = ModelBuilder::new(Unit::Millimeter, true);
-    ///
-    /// // Create a sub-model in inches
-    /// let sub_builder = ModelBuilder::new(Unit::Inch, false);
-    /// ```
     pub fn new(unit: Unit, is_root: bool) -> Self {
         Self {
             unit: Some(unit),
@@ -371,6 +227,15 @@ impl ModelBuilder {
             is_root,
             next_object_id: 1.into(),
             next_slicestack_id: 1.into(),
+            next_colorgroup_id: 1,
+            next_texture2dgroup_id: 1,
+            next_texture2d_id: 1,
+            next_composite_materials_id: 1,
+            next_multi_properties_id: 1,
+            next_basematerials_id: 1,
+            next_displacement2d_id: 1,
+            next_normvectorgroup_id: 1,
+            next_disp2dgroup_id: 1,
             is_production_ext_required: false,
         }
     }
@@ -410,22 +275,6 @@ impl ModelBuilder {
     ///
     /// Returns [`ProductionExtensionError`] if any existing objects, components, builds,
     /// or build items are missing required UUIDs.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// let mut builder = ModelBuilder::new(Unit::Millimeter, true);
-    ///
-    /// // Enable production extension first
-    /// builder.make_production_extension_required()?;
-    ///
-    /// // Now all objects and items require UUIDs
-    /// let obj_id = builder.add_mesh_object(|obj| {
-    ///     obj.uuid("unique-object-id");  // Required!
-    ///     obj.name("Part");
-    ///     Ok(())
-    /// })?;
-    /// ```
     pub fn make_production_extension_required(
         &mut self,
     ) -> Result<&mut Self, ProductionExtensionError> {
@@ -514,25 +363,6 @@ impl ModelBuilder {
     /// # Returns
     ///
     /// The auto-assigned [`ObjectId`] for the created object.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// let cube_id = builder.add_mesh_object(|obj| {
-    ///     obj.name("Cube")
-    ///        .object_type(ObjectType::Model);
-    ///
-    ///     // Add geometry
-    ///     obj.add_vertices(&[
-    ///         [0.0, 0.0, 0.0],
-    ///         [10.0, 0.0, 0.0],
-    ///         [0.0, 10.0, 0.0],
-    ///     ]);
-    ///     obj.add_triangles(&[[0, 1, 2]]);
-    ///
-    ///     Ok(())
-    /// })?;
-    /// ```
     pub fn add_mesh_object<F>(&mut self, f: F) -> Result<ObjectId, MeshObjectError>
     where
         F: FnOnce(&mut MeshObjectBuilder) -> Result<(), MeshObjectError>,
@@ -566,6 +396,41 @@ impl ModelBuilder {
         Ok(id)
     }
 
+    /// Add a displacement mesh object to the model using a builder closure.
+    pub fn add_displacement_mesh_object<F>(
+        &mut self,
+        f: F,
+    ) -> Result<ObjectId, DisplacementMeshObjectError>
+    where
+        F: FnOnce(&mut DisplacementMeshObjectBuilder) -> Result<(), DisplacementMeshObjectError>,
+    {
+        let id = self.next_object_id;
+
+        let mut obj_builder =
+            DisplacementMeshObjectBuilder::new(id, self.is_production_ext_required);
+        f(&mut obj_builder)?;
+
+        self.add_displacement_mesh_object_from_builder(obj_builder)
+    }
+
+    /// Add a displacement mesh object from a pre-configured [`DisplacementMeshObjectBuilder`].
+    pub fn add_displacement_mesh_object_from_builder(
+        &mut self,
+        builder: DisplacementMeshObjectBuilder,
+    ) -> Result<ObjectId, DisplacementMeshObjectError> {
+        let id = builder.object_id;
+        let object = builder.build()?;
+
+        if let Some(mesh) = object.get_displacement_mesh() {
+            self.set_recommended_namespaces_for_triangle_sets(mesh.trianglesets.is_some());
+        }
+
+        self.resources.objects.push(object);
+        self.next_object_id = ObjectId(id.0 + 1);
+
+        Ok(id)
+    }
+
     /// Add a components (assembly) object to the model using a builder closure.
     ///
     /// Components objects reference other objects to create assemblies or composed parts.
@@ -580,33 +445,6 @@ impl ModelBuilder {
     /// # Returns
     ///
     /// The auto-assigned [`ObjectId`] for the created object.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// // First create a mesh object
-    /// let part_id = builder.add_mesh_object(|obj| {
-    ///     obj.name("Part");
-    ///     obj.add_vertex(&[0.0, 0.0, 0.0]);
-    ///     obj.add_triangle(&[0, 1, 2]);
-    ///     Ok(())
-    /// })?;
-    ///
-    /// // Create an assembly that references the part multiple times
-    /// let assembly_id = builder.add_components_object(|obj| {
-    ///     obj.name("Assembly");
-    ///
-    ///     // Add first instance
-    ///     obj.add_component(part_id);
-    ///
-    ///     // Add second instance with transform
-    ///     obj.add_component_advanced(part_id, |comp| {
-    ///         comp.transform(Transform([1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 10.0, 0.0, 0.0]));
-    ///     });
-    ///
-    ///     Ok(())
-    /// })?;
-    /// ```
     pub fn add_components_object<F>(&mut self, f: F) -> Result<ObjectId, ComponentsObjectError>
     where
         F: FnOnce(&mut ComponentsObjectBuilder) -> Result<(), ComponentsObjectError>,
@@ -667,31 +505,6 @@ impl ModelBuilder {
     ///
     /// Returns [`BooleanShapeError`] if validation fails (e.g., missing base object,
     /// no operands, or missing UUID when Production extension is enabled).
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// // First create base and operand mesh objects
-    /// let cube_id = builder.add_mesh_object(|obj| {
-    ///     obj.name("Cube");
-    ///     // ... add cube geometry
-    ///     Ok(())
-    /// })?;
-    ///
-    /// let sphere_id = builder.add_mesh_object(|obj| {
-    ///     obj.name("Sphere");
-    ///     // ... add sphere geometry  
-    ///     Ok(())
-    /// })?;
-    ///
-    /// // Create boolean shape: cube minus sphere
-    /// let result_id = builder.add_booleanshape_object(|obj| {
-    ///     obj.name("CubeMinusSphere");
-    ///     obj.base_object(cube_id, BooleanOperation::Difference);
-    ///     obj.add_boolean(sphere_id);
-    ///     Ok(())
-    /// })?;
-    /// ```
     pub fn add_booleanshape_object<F>(&mut self, f: F) -> Result<ObjectId, BooleanShapeError>
     where
         F: FnOnce(&mut BooleanObjectBuilder) -> Result<(), BooleanShapeError>,
@@ -738,17 +551,6 @@ impl ModelBuilder {
     ///
     /// Returns [`ModelError::BuildOnlyAllowedInRootModel`] if called on a sub-model.
     /// Returns [`BuildError::BuildUuidNotSet`] if Production extension is enabled but no UUID is provided.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// // Simple build without UUID
-    /// builder.add_build(None)?;
-    ///
-    /// // With Production extension
-    /// builder.make_production_extension_required()?;
-    /// builder.add_build(Some(UuidResource::from("build-12345")))?;
-    /// ```
     pub fn add_build(&mut self, uuid: Option<UuidResource>) -> Result<&mut Self, ModelError> {
         if !self.is_root {
             return Err(ModelError::BuildOnlyAllowedInRootModel);
@@ -777,14 +579,6 @@ impl ModelBuilder {
     /// # Errors
     ///
     /// Returns [`ModelError::BuildItemNotSet`] if [`add_build()`](ModelBuilder::add_build) hasn't been called yet.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// builder.add_build(None)?;
-    /// let obj_id = builder.add_mesh_object(|obj| { /* ... */ Ok(()) })?;
-    /// builder.add_build_item(obj_id)?;
-    /// ```
     pub fn add_build_item(&mut self, object_id: ObjectId) -> Result<&mut Self, ModelError> {
         self.add_build_item_advanced(object_id, |_f| {})
     }
@@ -802,16 +596,6 @@ impl ModelBuilder {
     /// # Errors
     ///
     /// Returns [`ModelError::BuildItemNotSet`] if [`add_build()`](ModelBuilder::add_build) hasn't been called yet.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// builder.add_build_item_advanced(obj_id, |item| {
-    ///     item.transform(Transform([1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 10.0, 0.0, 0.0]));
-    ///     item.partnumber("PART-001");
-    ///     item.uuid("item-uuid");  // Required if Production extension enabled
-    /// })?;
-    /// ```
     pub fn add_build_item_advanced<F>(
         &mut self,
         object_id: ObjectId,
@@ -843,24 +627,6 @@ impl ModelBuilder {
     ///
     /// The assigned slice stack ID as [`ResourceId`]
     ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// let stack_id = builder.add_slice_stack(|stack| {
-    ///     stack.zbottom(0.0);
-    ///     
-    ///     // Add a slice layer
-    ///     stack.add_slice(|slice| {
-    ///         slice.ztop(0.1);
-    ///         slice.add_vertices(&[(0.0, 0.0), (10.0, 0.0), (10.0, 10.0)]);
-    ///         slice.add_polygon(|poly| {
-    ///             poly.start_vertex(0);
-    ///             poly.add_segment(1);
-    ///             poly.add_segment(2);
-    ///         });
-    ///     });
-    /// });
-    /// ```
     pub fn add_slice_stack<F>(&mut self, f: F) -> Result<SliceStackId, SliceStackBuilderError>
     where
         F: FnOnce(&mut SliceStackBuilder),
@@ -894,6 +660,132 @@ impl ModelBuilder {
         Ok(SliceStackId(id.0))
     }
 
+    /// Add a color group resource.
+    pub fn add_color_group<F>(&mut self, f: F) -> ResourceId
+    where
+        F: FnOnce(&mut ColorGroupBuilder),
+    {
+        let id = self.next_colorgroup_id;
+        let mut builder = ColorGroupBuilder::new(id);
+        f(&mut builder);
+        self.resources.colorgroup.push(builder.build());
+        self.next_colorgroup_id += 1;
+        id
+    }
+
+    /// Add a texture2d resource.
+    pub fn add_texture2d<F>(&mut self, f: F) -> Result<ResourceId, Texture2DError>
+    where
+        F: FnOnce(&mut Texture2DBuilder),
+    {
+        let id = self.next_texture2d_id;
+        let mut builder = Texture2DBuilder::new(id);
+        f(&mut builder);
+        let texture = builder.build()?;
+        self.resources.texture2d.push(texture);
+        self.next_texture2d_id += 1;
+        Ok(id)
+    }
+
+    /// Add a texture2d group resource.
+    pub fn add_texture2d_group<F>(&mut self, f: F) -> Result<ResourceId, Texture2DGroupError>
+    where
+        F: FnOnce(&mut Texture2DGroupBuilder),
+    {
+        let id = self.next_texture2dgroup_id;
+        let mut builder = Texture2DGroupBuilder::new(id);
+        f(&mut builder);
+        let group = builder.build()?;
+        self.resources.texture2dgroup.push(group);
+        self.next_texture2dgroup_id += 1;
+        Ok(id)
+    }
+
+    /// Add a composite materials resource.
+    pub fn add_composite_materials<F>(
+        &mut self,
+        f: F,
+    ) -> Result<ResourceId, CompositeMaterialsError>
+    where
+        F: FnOnce(&mut CompositeMaterialsBuilder),
+    {
+        let id = self.next_composite_materials_id;
+        let mut builder = CompositeMaterialsBuilder::new(id);
+        f(&mut builder);
+        let materials = builder.build()?;
+        self.resources.compositematerials.push(materials);
+        self.next_composite_materials_id += 1;
+        Ok(id)
+    }
+
+    /// Add a multi-properties resource.
+    pub fn add_multi_properties<F>(&mut self, f: F) -> Result<ResourceId, MultiPropertiesError>
+    where
+        F: FnOnce(&mut MultiPropertiesBuilder),
+    {
+        let id = self.next_multi_properties_id;
+        let mut builder = MultiPropertiesBuilder::new(id);
+        f(&mut builder);
+        let props = builder.build()?;
+        self.resources.multiproperties.push(props);
+        self.next_multi_properties_id += 1;
+        Ok(id)
+    }
+
+    /// Add a base materials resource.
+    pub fn add_base_materials<F>(&mut self, f: F) -> ResourceId
+    where
+        F: FnOnce(&mut BaseMaterialsBuilder),
+    {
+        let id = self.next_basematerials_id;
+        let mut builder = BaseMaterialsBuilder::new(id);
+        f(&mut builder);
+        self.resources.basematerials.push(builder.build());
+        self.next_basematerials_id += 1;
+        id
+    }
+
+    /// Add a displacement2d resource.
+    pub fn add_displacement2d<F>(&mut self, f: F) -> Result<ResourceId, Displacement2DError>
+    where
+        F: FnOnce(&mut Displacement2DBuilder),
+    {
+        let id = self.next_displacement2d_id;
+        let mut builder = Displacement2DBuilder::new(id);
+        f(&mut builder);
+        let displacement = builder.build()?;
+        self.resources.displacement2d.push(displacement);
+        self.next_displacement2d_id += 1;
+        Ok(id)
+    }
+
+    /// Add a norm vector group resource.
+    pub fn add_norm_vector_group<F>(&mut self, f: F) -> ResourceId
+    where
+        F: FnOnce(&mut NormVectorGroupBuilder),
+    {
+        let id = self.next_normvectorgroup_id;
+        let mut builder = NormVectorGroupBuilder::new(id);
+        f(&mut builder);
+        self.resources.normvectorgroup.push(builder.build());
+        self.next_normvectorgroup_id += 1;
+        id
+    }
+
+    /// Add a displacement 2d group resource.
+    pub fn add_disp2d_group<F>(&mut self, f: F) -> Result<ResourceId, Disp2DGroupError>
+    where
+        F: FnOnce(&mut Disp2DGroupBuilder),
+    {
+        let id = self.next_disp2dgroup_id;
+        let mut builder = Disp2DGroupBuilder::new(id);
+        f(&mut builder);
+        let group = builder.build()?;
+        self.resources.disp2dgroup.push(group);
+        self.next_disp2dgroup_id += 1;
+        Ok(id)
+    }
+
     /// Build the final [`Model`].
     ///
     /// This consumes the builder and performs final validation:
@@ -904,12 +796,6 @@ impl ModelBuilder {
     /// # Errors
     ///
     /// Returns [`ModelError`] if validation fails.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// let model = builder.build()?;
-    /// ```
     pub fn build(self) -> Result<Model, ModelError> {
         let required_extensions = self.process_required_extensions();
 
@@ -944,11 +830,14 @@ impl ModelBuilder {
     }
 
     fn set_recommended_namespaces_for_mesh(&mut self, mesh: &Mesh) {
-        if mesh.trianglesets.is_some()
-            && self
+        self.set_recommended_namespaces_for_triangle_sets(mesh.trianglesets.is_some());
+    }
+
+    fn set_recommended_namespaces_for_triangle_sets(&mut self, has_triangle_sets: bool) {
+        if has_triangle_sets
+            && !self
                 .recommendedextensions
-                .iter()
-                .all(|ns| *ns == ThreemfNamespace::CoreTriangleSet)
+                .contains(&ThreemfNamespace::CoreTriangleSet)
         {
             self.recommendedextensions
                 .push(ThreemfNamespace::CoreTriangleSet);
@@ -971,6 +860,12 @@ impl ModelBuilder {
 
         for object in &self.resources.objects {
             if let Some(mesh) = object.get_mesh()
+                && let Some(beam_lattice) = &mesh.beamlattice
+            {
+                is_beam_lattice_required = true;
+                is_beam_lattice_balls_required = beam_lattice.balls.is_some();
+            }
+            if let Some(mesh) = object.get_displacement_mesh()
                 && let Some(beam_lattice) = &mesh.beamlattice
             {
                 is_beam_lattice_required = true;
@@ -1016,6 +911,7 @@ impl ModelBuilder {
         let is_slice_required = !self.resources.slicestack.is_empty()
             || self.resources.objects.iter().any(|obj| {
                 obj.slicestackid.is_some()
+                    || obj.slicepath.is_some()
                     || matches!(obj.meshresolution, Some(MeshResolution::LowRes))
             });
 
@@ -1025,6 +921,117 @@ impl ModelBuilder {
                 .find(|ns| **ns == ThreemfNamespace::Slice);
             if is_slice_ext_set.is_none() {
                 required_extensions.push(ThreemfNamespace::Slice);
+            }
+        }
+
+        let has_material_resources = !self.resources.basematerials.is_empty()
+            || !self.resources.colorgroup.is_empty()
+            || !self.resources.texture2dgroup.is_empty()
+            || !self.resources.texture2d.is_empty()
+            || !self.resources.compositematerials.is_empty()
+            || !self.resources.multiproperties.is_empty();
+
+        let has_material_references =
+            self.resources.objects.iter().any(|obj| {
+                if obj.pid.is_some() || obj.pindex.is_some() {
+                    return true;
+                }
+
+                if let Some(mesh) = obj.get_mesh() {
+                    if mesh.triangles.triangle.iter().any(|t| {
+                        t.pid.is_some() || t.p1.is_some() || t.p2.is_some() || t.p3.is_some()
+                    }) {
+                        return true;
+                    }
+
+                    if let Some(lattice) = &mesh.beamlattice {
+                        if lattice.pid.is_some() || lattice.pindex.is_some() {
+                            return true;
+                        }
+
+                        if lattice.beams.beam.iter().any(|beam| {
+                            beam.pid.is_some() || beam.p1.is_some() || beam.p2.is_some()
+                        }) {
+                            return true;
+                        }
+
+                        if let Some(balls) = &lattice.balls
+                            && balls
+                                .ball
+                                .iter()
+                                .any(|ball| ball.pid.is_some() || ball.p.is_some())
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                if let Some(mesh) = obj.get_displacement_mesh() {
+                    if mesh.triangles.triangle.iter().any(|t| {
+                        t.pid.is_some() || t.p1.is_some() || t.p2.is_some() || t.p3.is_some()
+                    }) {
+                        return true;
+                    }
+
+                    if let Some(lattice) = &mesh.beamlattice {
+                        if lattice.pid.is_some() || lattice.pindex.is_some() {
+                            return true;
+                        }
+
+                        if lattice.beams.beam.iter().any(|beam| {
+                            beam.pid.is_some() || beam.p1.is_some() || beam.p2.is_some()
+                        }) {
+                            return true;
+                        }
+
+                        if let Some(balls) = &lattice.balls
+                            && balls
+                                .ball
+                                .iter()
+                                .any(|ball| ball.pid.is_some() || ball.p.is_some())
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                false
+            }) || self.resources.slicestack.iter().any(|stack| {
+                stack.slice.iter().any(|slice| {
+                    slice.polygon.iter().any(|polygon| {
+                        polygon
+                            .segment
+                            .iter()
+                            .any(|seg| seg.pid.is_some() || seg.p1.is_some() || seg.p2.is_some())
+                    })
+                })
+            });
+
+        if has_material_resources || has_material_references {
+            let is_material_ext_set = required_extensions
+                .iter()
+                .find(|ns| **ns == ThreemfNamespace::Material);
+            if is_material_ext_set.is_none() {
+                required_extensions.push(ThreemfNamespace::Material);
+            }
+        }
+
+        let has_displacement_resources = !self.resources.displacement2d.is_empty()
+            || !self.resources.normvectorgroup.is_empty()
+            || !self.resources.disp2dgroup.is_empty();
+
+        let has_displacement_mesh = self
+            .resources
+            .objects
+            .iter()
+            .any(|obj| obj.get_displacement_mesh().is_some());
+
+        if has_displacement_resources || has_displacement_mesh {
+            let is_displacement_ext_set = required_extensions
+                .iter()
+                .find(|ns| **ns == ThreemfNamespace::Displacement);
+            if is_displacement_ext_set.is_none() {
+                required_extensions.push(ThreemfNamespace::Displacement);
             }
         }
 
@@ -1042,6 +1049,15 @@ impl Default for ModelBuilder {
 pub struct ResourcesBuilder {
     objects: Vec<Object>,
     slicestack: Vec<SliceStack>,
+    colorgroup: Vec<ColorGroup>,
+    texture2dgroup: Vec<Texture2DGroup>,
+    texture2d: Vec<Texture2D>,
+    compositematerials: Vec<CompositeMaterials>,
+    multiproperties: Vec<MultiProperties>,
+    basematerials: Vec<BaseMaterials>,
+    displacement2d: Vec<Displacement2D>,
+    normvectorgroup: Vec<NormVectorGroup>,
+    disp2dgroup: Vec<Disp2DGroup>,
 }
 
 impl ResourcesBuilder {
@@ -1049,22 +1065,31 @@ impl ResourcesBuilder {
         Self {
             objects: Vec::new(),
             slicestack: Vec::new(),
+            colorgroup: Vec::new(),
+            texture2dgroup: Vec::new(),
+            texture2d: Vec::new(),
+            compositematerials: Vec::new(),
+            multiproperties: Vec::new(),
+            basematerials: Vec::new(),
+            displacement2d: Vec::new(),
+            normvectorgroup: Vec::new(),
+            disp2dgroup: Vec::new(),
         }
     }
 
     fn build(self) -> Resources {
         Resources {
             object: self.objects,
-            basematerials: Vec::new(),
+            basematerials: self.basematerials,
             slicestack: self.slicestack,
-            colorgroup: Vec::new(),
-            texture2dgroup: Vec::new(),
-            compositematerials: Vec::new(),
-            multiproperties: Vec::new(),
-            texture2d: Vec::new(),
-            displacement2d: Vec::new(),
-            normvectorgroup: Vec::new(),
-            disp2dgroup: Vec::new(),
+            colorgroup: self.colorgroup,
+            texture2dgroup: self.texture2dgroup,
+            compositematerials: self.compositematerials,
+            multiproperties: self.multiproperties,
+            texture2d: self.texture2d,
+            displacement2d: self.displacement2d,
+            normvectorgroup: self.normvectorgroup,
+            disp2dgroup: self.disp2dgroup,
         }
     }
 }
@@ -1154,6 +1179,56 @@ pub enum ItemError {
     ItemUuidNotSet,
 }
 
+/// Errors that can occur when building a Texture2D resource.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum Texture2DError {
+    #[error("Texture2D path is not set")]
+    PathNotSet,
+    #[error("Texture2D content type is not set")]
+    ContentTypeNotSet,
+}
+
+/// Errors that can occur when building a Texture2DGroup resource.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum Texture2DGroupError {
+    #[error("Texture2DGroup texid is not set")]
+    TexIdNotSet,
+}
+
+/// Errors that can occur when building CompositeMaterials.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum CompositeMaterialsError {
+    #[error("CompositeMaterials matid is not set")]
+    MatIdNotSet,
+    #[error("CompositeMaterials matindices are empty")]
+    MatIndicesEmpty,
+}
+
+/// Errors that can occur when building MultiProperties.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum MultiPropertiesError {
+    #[error("MultiProperties pids are empty")]
+    PidsEmpty,
+}
+
+/// Errors that can occur when building Displacement2D.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum Displacement2DError {
+    #[error("Displacement2D path is not set")]
+    PathNotSet,
+}
+
+/// Errors that can occur when building Disp2DGroup.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum Disp2DGroupError {
+    #[error("Disp2DGroup displacement id is not set")]
+    DispIdNotSet,
+    #[error("Disp2DGroup norm vector group id is not set")]
+    NormVectorGroupIdNotSet,
+    #[error("Disp2DGroup height is not set")]
+    HeightNotSet,
+}
+
 /// Builder for configuring a build item.
 ///
 /// Build items specify which objects should be manufactured and how they should
@@ -1184,26 +1259,6 @@ impl ItemBuilder {
     ///
     /// The transform is a 4x3 affine transformation matrix stored as a 12-element array
     /// in row-major order.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// // Identity transform (no transformation)
-    /// comp.transform(Transform([
-    ///     1.0, 0.0, 0.0,
-    ///     0.0, 1.0, 0.0,
-    ///     0.0, 0.0, 1.0,
-    ///     0.0, 0.0, 0.0
-    /// ]));
-    ///
-    /// // Translate 10mm in X direction
-    /// comp.transform(Transform([
-    ///     1.0, 0.0, 0.0,
-    ///     0.0, 1.0, 0.0,
-    ///     0.0, 0.0, 1.0,
-    ///     10.0, 0.0, 0.0
-    /// ]));
-    /// ```
     pub fn transform(&mut self, transform: Transform) -> &mut Self {
         self.transform = Some(transform);
         self
@@ -1298,6 +1353,9 @@ pub struct ObjectBuilder<T> {
     pid: OptionalResourceId,
     pindex: OptionalResourceIndex,
     uuid: Option<UuidResource>,
+    slicestackid: OptionalResourceId,
+    slicepath: Option<PathResource>,
+    meshresolution: Option<MeshResolution>,
 
     // sets if the production ext is required.
     // if yes will ensure UUID is set before building the object
@@ -1309,6 +1367,17 @@ impl<T> ObjectBuilder<T> {
     pub fn object_type(&mut self, object_type: ObjectType) -> &mut Self {
         self.objecttype = Some(object_type);
         self
+    }
+
+    /// Set a thumbnail path for this object.
+    pub fn thumbnail(&mut self, path: &str) -> &mut Self {
+        match PathResource::try_from(path) {
+            Ok(path) => {
+                self.thumbnail = Some(path);
+                self
+            }
+            Err(err) => panic!("{err:?}"),
+        }
     }
 
     /// Set the object name
@@ -1325,6 +1394,58 @@ impl<T> ObjectBuilder<T> {
 
     pub fn uuid(&mut self, uuid: &str) -> &mut Self {
         self.uuid = Some(UuidResource::from(uuid));
+        self
+    }
+
+    /// Set the property resource ID for this object.
+    pub fn pid(&mut self, pid: ResourceId) -> &mut Self {
+        self.pid = OptionalResourceId::new(pid);
+        self
+    }
+
+    /// Set the property index for this object.
+    pub fn pindex(&mut self, pindex: ResourceIndex) -> &mut Self {
+        self.pindex = OptionalResourceIndex::new(pindex);
+        self
+    }
+
+    /// Set the slice stack reference for this object.
+    pub fn slice_stack_id(&mut self, slicestack_id: SliceStackId) -> &mut Self {
+        self.slicestackid = OptionalResourceId::new(slicestack_id.0);
+        self
+    }
+
+    /// Set the slice path for this object.
+    pub fn slicepath(&mut self, slicepath: &str) -> &mut Self {
+        match PathResource::try_from(slicepath) {
+            Ok(path) => {
+                self.slicepath = Some(path);
+                self
+            }
+            Err(err) => panic!("{err:?}"),
+        }
+    }
+
+    /// Set the mesh resolution for this object when slice data is present.
+    pub fn meshresolution(&mut self, resolution: MeshResolution) -> &mut Self {
+        self.meshresolution = Some(resolution);
+        self
+    }
+
+    /// Configure slice stack attributes together.
+    pub fn slice_stack(
+        &mut self,
+        slicestack_id: SliceStackId,
+        slicepath: Option<&str>,
+        meshresolution: Option<MeshResolution>,
+    ) -> &mut Self {
+        self.slice_stack_id(slicestack_id);
+        if let Some(path) = slicepath {
+            self.slicepath(path);
+        }
+        if let Some(resolution) = meshresolution {
+            self.meshresolution(resolution);
+        }
         self
     }
 }
@@ -1353,36 +1474,20 @@ pub enum MeshObjectError {
     ObjectUuidNotSet,
 }
 
+/// Errors that can occur when building a displacement mesh object.
+#[derive(Debug, Error, Clone, PartialEq)]
+pub enum DisplacementMeshObjectError {
+    /// Object is missing a UUID when Production extension is required.
+    ///
+    /// Call [`DisplacementMeshObjectBuilder::uuid()`] to set the UUID.
+    #[error("Production extension is enabled but Uuid is not set!")]
+    ObjectUuidNotSet,
+}
+
 /// Builder for creating mesh objects with triangle geometry.
 ///
 /// `MeshObjectBuilder` combines object metadata (name, type, UUID, etc.) with
 /// mesh geometry. Access mesh-building methods directly via [`Deref`] to [`MeshBuilder`].
-///
-/// # Examples
-///
-/// ```rust,ignore
-/// let cube_id = builder.add_mesh_object(|obj| {
-///     // Object properties
-///     obj.name("Cube")
-///        .object_type(ObjectType::Model)
-///        .part_number("CUBE-001");
-///
-///     // Mesh geometry (via Deref to MeshBuilder)
-///     obj.add_vertices(&[
-///         [0.0, 0.0, 0.0],
-///         [10.0, 0.0, 0.0],
-///         [10.0, 10.0, 0.0],
-///         [0.0, 10.0, 0.0],
-///     ]);
-///
-///     obj.add_triangles(&[
-///         [0, 1, 2],
-///         [0, 2, 3],
-///     ]);
-///
-///     Ok(())
-/// })?;
-/// ```
 pub type MeshObjectBuilder = ObjectBuilder<MeshBuilder>;
 
 impl MeshObjectBuilder {
@@ -1397,6 +1502,9 @@ impl MeshObjectBuilder {
             pid: OptionalResourceId::none(),
             pindex: OptionalResourceIndex::none(),
             uuid: None,
+            slicestackid: OptionalResourceId::none(),
+            slicepath: None,
+            meshresolution: None,
             is_production_ext_required,
         }
     }
@@ -1417,11 +1525,57 @@ impl MeshObjectBuilder {
             pid: self.pid,
             pindex: self.pindex,
             uuid: self.uuid,
-            slicestackid: crate::core::OptionalResourceId::none(),
-            slicepath: None,
-            meshresolution: None,
+            slicestackid: self.slicestackid,
+            slicepath: self.slicepath,
+            meshresolution: self.meshresolution,
             kind: Some(ObjectKind::Mesh(mesh)),
             // mesh: Some(mesh),
+        })
+    }
+}
+
+/// Builder for creating displacement mesh objects.
+pub type DisplacementMeshObjectBuilder = ObjectBuilder<DisplacementMeshBuilder>;
+
+impl DisplacementMeshObjectBuilder {
+    fn new(object_id: ObjectId, is_production_ext_required: bool) -> Self {
+        Self {
+            entity: DisplacementMeshBuilder::new(),
+            object_id,
+            objecttype: Some(ObjectType::Model),
+            thumbnail: None,
+            partnumber: None,
+            name: None,
+            pid: OptionalResourceId::none(),
+            pindex: OptionalResourceIndex::none(),
+            uuid: None,
+            slicestackid: OptionalResourceId::none(),
+            slicepath: None,
+            meshresolution: None,
+            is_production_ext_required,
+        }
+    }
+
+    fn build(self) -> Result<Object, DisplacementMeshObjectError> {
+        let mesh = self.entity.build_mesh();
+
+        if self.is_production_ext_required && self.uuid.is_none() {
+            return Err(DisplacementMeshObjectError::ObjectUuidNotSet);
+        }
+
+        Ok(Object {
+            id: self.object_id.0,
+            objecttype: self.objecttype,
+            thumbnail: self.thumbnail,
+            partnumber: self.partnumber.map(Into::into),
+            name: self.name.map(Into::into),
+            pid: self.pid,
+            pindex: self.pindex,
+            uuid: self.uuid,
+            slicestackid: self.slicestackid,
+            slicepath: self.slicepath,
+            meshresolution: self.meshresolution,
+            kind: Some(ObjectKind::DisplacementMesh(mesh)),
         })
     }
 }
@@ -1433,20 +1587,6 @@ impl MeshObjectBuilder {
 ///
 /// Vertices are referenced by their 0-based index in the order they were added.
 /// Triangles reference vertices by index.
-///
-/// # Examples
-///
-/// ```rust,ignore
-/// obj.add_vertices(&[
-///     [0.0, 0.0, 0.0],   // vertex 0
-///     [10.0, 0.0, 0.0],  // vertex 1
-///     [10.0, 10.0, 0.0], // vertex 2
-/// ]);
-///
-/// obj.add_triangles(&[
-///     [0, 1, 2],  // Triangle using vertices 0, 1, 2
-/// ]);
-/// ```
 pub struct MeshBuilder {
     vertices: Vec<Vertex>,
     triangles: Vec<Triangle>,
@@ -1471,14 +1611,6 @@ impl MeshBuilder {
     /// # Parameters
     ///
     /// - `coords`: 3D coordinates as `[x, y, z]`
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// obj.add_vertex(&[0.0, 0.0, 0.0])
-    ///    .add_vertex(&[10.0, 0.0, 0.0])
-    ///    .add_vertex(&[0.0, 10.0, 0.0]);
-    /// ```
     pub fn add_vertex(&mut self, coords: &[f64; 3]) -> &mut Self {
         self.vertices
             .push(Vertex::new(coords[0], coords[1], coords[2]));
@@ -1488,16 +1620,6 @@ impl MeshBuilder {
     /// Add multiple vertices from a slice of coordinate arrays.
     ///
     /// Each element should be a 3D coordinate `[x, y, z]`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// obj.add_vertices(&[
-    ///     [0.0, 0.0, 0.0],
-    ///     [10.0, 0.0, 0.0],
-    ///     [10.0, 10.0, 0.0],
-    /// ]);
-    /// ```
     pub fn add_vertices(&mut self, vertices: &[[f64; 3]]) -> &mut Self {
         for vertex in vertices {
             self.add_vertex(vertex);
@@ -1510,16 +1632,6 @@ impl MeshBuilder {
     ///
     /// The slice should contain coordinate values in sequence: `[x0, y0, z0, x1, y1, z1, ...]`.
     /// The length must be a multiple of 3.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// obj.add_vertices_flat(&[
-    ///     0.0, 0.0, 0.0,     // vertex 0
-    ///     10.0, 0.0, 0.0,    // vertex 1
-    ///     10.0, 10.0, 0.0,   // vertex 2
-    /// ]);
-    /// ```
     pub fn add_vertices_flat(&mut self, vertices: &[f64]) -> &mut Self {
         for vertex in vertices.chunks_exact(3) {
             self.vertices
@@ -1537,15 +1649,6 @@ impl MeshBuilder {
     /// # Parameters
     ///
     /// - `indices`: Triangle vertex indices as `[v1, v2, v3]`
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// obj.add_vertex(&[0.0, 0.0, 0.0]);    // index 0
-    /// obj.add_vertex(&[10.0, 0.0, 0.0]);   // index 1
-    /// obj.add_vertex(&[0.0, 10.0, 0.0]);   // index 2
-    /// obj.add_triangle(&[0, 1, 2]);
-    /// ```
     pub fn add_triangle(&mut self, indices: &[usize; 3]) -> &mut Self {
         self.triangles.push(Triangle {
             v1: indices[0] as ResourceIndex,
@@ -1559,19 +1662,44 @@ impl MeshBuilder {
         self
     }
 
+    /// Add a triangle with explicit property references.
+    pub fn add_triangle_with_properties(
+        &mut self,
+        indices: &[usize; 3],
+        p1: OptionalResourceIndex,
+        p2: OptionalResourceIndex,
+        p3: OptionalResourceIndex,
+        pid: OptionalResourceId,
+    ) -> &mut Self {
+        self.triangles.push(Triangle {
+            v1: indices[0] as ResourceIndex,
+            v2: indices[1] as ResourceIndex,
+            v3: indices[2] as ResourceIndex,
+            p1,
+            p2,
+            p3,
+            pid,
+        });
+        self
+    }
+
+    /// Add a triangle with advanced configuration.
+    pub fn add_triangle_advanced<F>(&mut self, indices: &[usize; 3], f: F) -> &mut Self
+    where
+        F: FnOnce(TriangleBuilder) -> TriangleBuilder,
+    {
+        let builder = TriangleBuilder::new(
+            indices[0] as ResourceIndex,
+            indices[1] as ResourceIndex,
+            indices[2] as ResourceIndex,
+        );
+        self.triangles.push(f(builder).build());
+        self
+    }
+
     /// Add multiple triangles from a slice of index arrays.
     ///
     /// Each element should be a triangle with three vertex indices.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// obj.add_triangles(&[
-    ///     [0, 1, 2],
-    ///     [0, 2, 3],
-    ///     [0, 3, 4],
-    /// ]);
-    /// ```
     pub fn add_triangles(&mut self, triangles: &[[usize; 3]]) -> &mut Self {
         for triangle in triangles {
             self.add_triangle(triangle);
@@ -1584,15 +1712,6 @@ impl MeshBuilder {
     ///
     /// The slice should contain vertex indices in sequence: `[v1, v2, v3, v1, v2, v3, ...]`.
     /// The length must be a multiple of 3.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// obj.add_triangles_flat(&[
-    ///     0, 1, 2,  // triangle 0
-    ///     0, 2, 3,  // triangle 1
-    /// ]);
-    /// ```
     pub fn add_triangles_flat(&mut self, triangles: &[usize]) -> &mut Self {
         for triangle in triangles.chunks_exact(3) {
             self.triangles.push(Triangle {
@@ -1617,15 +1736,6 @@ impl MeshBuilder {
     /// # Parameters
     ///
     /// - `f`: A closure that configures the [`TriangleSetsBuilder`]
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// obj.add_triangle_sets(|sets| {
-    ///     sets.add_set("TopFace", "top-id", &[0, 1], &[]);
-    ///     sets.add_set("BottomFace", "bottom-id", &[2, 3], &[]);
-    /// });
-    /// ```
     pub fn add_triangle_sets<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut TriangleSetsBuilder),
@@ -1649,16 +1759,6 @@ impl MeshBuilder {
     /// # Parameters
     ///
     /// - `f`: A closure that configures the [`BeamLatticeBuilder`]
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// obj.add_beam_lattice(|lattice| {
-    ///     lattice.radius(0.5)
-    ///            .add_beam(0, 1)
-    ///            .add_beam(1, 2);
-    /// });
-    /// ```
     pub fn add_beam_lattice<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut BeamLatticeBuilder),
@@ -1686,6 +1786,330 @@ impl MeshBuilder {
             trianglesets,
             beamlattice,
         })
+    }
+}
+
+/// Builder for triangle properties in a mesh.
+pub struct TriangleBuilder {
+    v1: ResourceIndex,
+    v2: ResourceIndex,
+    v3: ResourceIndex,
+    p1: OptionalResourceIndex,
+    p2: OptionalResourceIndex,
+    p3: OptionalResourceIndex,
+    pid: OptionalResourceId,
+}
+
+impl TriangleBuilder {
+    fn new(v1: ResourceIndex, v2: ResourceIndex, v3: ResourceIndex) -> Self {
+        Self {
+            v1,
+            v2,
+            v3,
+            p1: OptionalResourceIndex::none(),
+            p2: OptionalResourceIndex::none(),
+            p3: OptionalResourceIndex::none(),
+            pid: OptionalResourceId::none(),
+        }
+    }
+
+    pub fn pindex_1(mut self, pindex: OptionalResourceIndex) -> Self {
+        self.p1 = pindex;
+        self
+    }
+
+    pub fn pindex_2(mut self, pindex: OptionalResourceIndex) -> Self {
+        self.p2 = pindex;
+        self
+    }
+
+    pub fn pindex_3(mut self, pindex: OptionalResourceIndex) -> Self {
+        self.p3 = pindex;
+        self
+    }
+
+    pub fn pid(mut self, pid: ResourceId) -> Self {
+        self.pid = OptionalResourceId::new(pid);
+        self
+    }
+
+    fn build(self) -> Triangle {
+        Triangle {
+            v1: self.v1,
+            v2: self.v2,
+            v3: self.v3,
+            p1: self.p1,
+            p2: self.p2,
+            p3: self.p3,
+            pid: self.pid,
+        }
+    }
+}
+
+/// Builder for constructing displacement mesh geometry.
+pub struct DisplacementMeshBuilder {
+    vertices: Vec<crate::core::displacement::Vertex>,
+    triangles: Vec<crate::core::displacement::Triangle>,
+    triangle_sets: Option<TriangleSetsBuilder>,
+    beam_lattice: Option<BeamLatticeBuilder>,
+    triangles_did: OptionalResourceId,
+}
+
+impl DisplacementMeshBuilder {
+    fn new() -> Self {
+        Self {
+            vertices: Vec::new(),
+            triangles: Vec::new(),
+            triangle_sets: None,
+            beam_lattice: None,
+            triangles_did: OptionalResourceId::none(),
+        }
+    }
+
+    /// Set the default displacement group ID for triangles.
+    pub fn displacement_id(&mut self, disp2dgroup_id: ResourceId) -> &mut Self {
+        self.triangles_did = OptionalResourceId::new(disp2dgroup_id);
+        self
+    }
+
+    pub fn add_vertex(&mut self, coords: &[f64; 3]) -> &mut Self {
+        self.vertices.push(crate::core::displacement::Vertex {
+            x: coords[0].into(),
+            y: coords[1].into(),
+            z: coords[2].into(),
+        });
+        self
+    }
+
+    pub fn add_vertices(&mut self, vertices: &[[f64; 3]]) -> &mut Self {
+        for vertex in vertices {
+            self.add_vertex(vertex);
+        }
+        self
+    }
+
+    pub fn add_vertices_flat(&mut self, vertices: &[f64]) -> &mut Self {
+        for vertex in vertices.chunks_exact(3) {
+            self.vertices.push(crate::core::displacement::Vertex {
+                x: vertex[0].into(),
+                y: vertex[1].into(),
+                z: vertex[2].into(),
+            });
+        }
+        self
+    }
+
+    pub fn add_triangle(&mut self, indices: &[usize; 3]) -> &mut Self {
+        self.triangles.push(crate::core::displacement::Triangle {
+            v1: indices[0] as ResourceIndex,
+            v2: indices[1] as ResourceIndex,
+            v3: indices[2] as ResourceIndex,
+            d1: OptionalResourceIndex::none(),
+            d2: OptionalResourceIndex::none(),
+            d3: OptionalResourceIndex::none(),
+            did: OptionalResourceId::none(),
+            p1: OptionalResourceIndex::none(),
+            p2: OptionalResourceIndex::none(),
+            p3: OptionalResourceIndex::none(),
+            pid: OptionalResourceId::none(),
+        });
+        self
+    }
+
+    pub fn add_triangle_with_properties(
+        &mut self,
+        indices: &[usize; 3],
+        p1: OptionalResourceIndex,
+        p2: OptionalResourceIndex,
+        p3: OptionalResourceIndex,
+        pid: OptionalResourceId,
+    ) -> &mut Self {
+        self.triangles.push(crate::core::displacement::Triangle {
+            v1: indices[0] as ResourceIndex,
+            v2: indices[1] as ResourceIndex,
+            v3: indices[2] as ResourceIndex,
+            d1: OptionalResourceIndex::none(),
+            d2: OptionalResourceIndex::none(),
+            d3: OptionalResourceIndex::none(),
+            did: OptionalResourceId::none(),
+            p1,
+            p2,
+            p3,
+            pid,
+        });
+        self
+    }
+
+    pub fn add_triangle_advanced<F>(&mut self, indices: &[usize; 3], f: F) -> &mut Self
+    where
+        F: FnOnce(DisplacementTriangleBuilder) -> DisplacementTriangleBuilder,
+    {
+        let builder = DisplacementTriangleBuilder::new(
+            indices[0] as ResourceIndex,
+            indices[1] as ResourceIndex,
+            indices[2] as ResourceIndex,
+        );
+        self.triangles.push(f(builder).build());
+        self
+    }
+
+    pub fn add_triangles(&mut self, triangles: &[[usize; 3]]) -> &mut Self {
+        for triangle in triangles {
+            self.add_triangle(triangle);
+        }
+        self
+    }
+
+    pub fn add_triangles_flat(&mut self, triangles: &[usize]) -> &mut Self {
+        for triangle in triangles.chunks_exact(3) {
+            self.triangles.push(crate::core::displacement::Triangle {
+                v1: triangle[0] as ResourceIndex,
+                v2: triangle[1] as ResourceIndex,
+                v3: triangle[2] as ResourceIndex,
+                d1: OptionalResourceIndex::none(),
+                d2: OptionalResourceIndex::none(),
+                d3: OptionalResourceIndex::none(),
+                did: OptionalResourceId::none(),
+                p1: OptionalResourceIndex::none(),
+                p2: OptionalResourceIndex::none(),
+                p3: OptionalResourceIndex::none(),
+                pid: OptionalResourceId::none(),
+            });
+        }
+        self
+    }
+
+    pub fn add_triangle_sets<F>(&mut self, f: F) -> &mut Self
+    where
+        F: FnOnce(&mut TriangleSetsBuilder),
+    {
+        if let Some(ref mut builder) = self.triangle_sets {
+            f(builder);
+        } else {
+            let mut builder = TriangleSetsBuilder::new();
+            f(&mut builder);
+            self.triangle_sets = Some(builder);
+        }
+        self
+    }
+
+    pub fn add_beam_lattice<F>(&mut self, f: F) -> &mut Self
+    where
+        F: FnOnce(&mut BeamLatticeBuilder),
+    {
+        if let Some(builder) = &mut self.beam_lattice {
+            f(builder);
+        } else {
+            let mut builder = BeamLatticeBuilder::new();
+            f(&mut builder);
+            self.beam_lattice = Some(builder);
+        }
+        self
+    }
+
+    fn build_mesh(self) -> DisplacementMesh {
+        let trianglesets = self.triangle_sets.map(|b| b.build());
+        let beamlattice = self.beam_lattice.map(|b| b.build());
+        DisplacementMesh {
+            vertices: crate::core::displacement::Vertices {
+                vertex: self.vertices,
+            },
+            triangles: crate::core::displacement::Triangles {
+                did: self.triangles_did,
+                triangle: self.triangles,
+            },
+            trianglesets,
+            beamlattice,
+        }
+    }
+}
+
+/// Builder for displacement mesh triangles.
+pub struct DisplacementTriangleBuilder {
+    v1: ResourceIndex,
+    v2: ResourceIndex,
+    v3: ResourceIndex,
+    d1: OptionalResourceIndex,
+    d2: OptionalResourceIndex,
+    d3: OptionalResourceIndex,
+    did: OptionalResourceId,
+    p1: OptionalResourceIndex,
+    p2: OptionalResourceIndex,
+    p3: OptionalResourceIndex,
+    pid: OptionalResourceId,
+}
+
+impl DisplacementTriangleBuilder {
+    fn new(v1: ResourceIndex, v2: ResourceIndex, v3: ResourceIndex) -> Self {
+        Self {
+            v1,
+            v2,
+            v3,
+            d1: OptionalResourceIndex::none(),
+            d2: OptionalResourceIndex::none(),
+            d3: OptionalResourceIndex::none(),
+            did: OptionalResourceId::none(),
+            p1: OptionalResourceIndex::none(),
+            p2: OptionalResourceIndex::none(),
+            p3: OptionalResourceIndex::none(),
+            pid: OptionalResourceId::none(),
+        }
+    }
+
+    pub fn displacement_index_1(mut self, index: OptionalResourceIndex) -> Self {
+        self.d1 = index;
+        self
+    }
+
+    pub fn displacement_index_2(mut self, index: OptionalResourceIndex) -> Self {
+        self.d2 = index;
+        self
+    }
+
+    pub fn displacement_index_3(mut self, index: OptionalResourceIndex) -> Self {
+        self.d3 = index;
+        self
+    }
+
+    pub fn displacement_id(mut self, disp2dgroup_id: ResourceId) -> Self {
+        self.did = OptionalResourceId::new(disp2dgroup_id);
+        self
+    }
+
+    pub fn pindex_1(mut self, pindex: OptionalResourceIndex) -> Self {
+        self.p1 = pindex;
+        self
+    }
+
+    pub fn pindex_2(mut self, pindex: OptionalResourceIndex) -> Self {
+        self.p2 = pindex;
+        self
+    }
+
+    pub fn pindex_3(mut self, pindex: OptionalResourceIndex) -> Self {
+        self.p3 = pindex;
+        self
+    }
+
+    pub fn pid(mut self, pid: ResourceId) -> Self {
+        self.pid = OptionalResourceId::new(pid);
+        self
+    }
+
+    fn build(self) -> crate::core::displacement::Triangle {
+        crate::core::displacement::Triangle {
+            v1: self.v1,
+            v2: self.v2,
+            v3: self.v3,
+            d1: self.d1,
+            d2: self.d2,
+            d3: self.d3,
+            did: self.did,
+            p1: self.p1,
+            p2: self.p2,
+            p3: self.p3,
+            pid: self.pid,
+        }
     }
 }
 
@@ -1778,6 +2202,9 @@ impl ComponentsObjectBuilder {
             pid: OptionalResourceId::none(),
             pindex: OptionalResourceIndex::none(),
             uuid: None,
+            slicestackid: OptionalResourceId::none(),
+            slicepath: None,
+            meshresolution: None,
             is_production_ext_required,
         }
     }
@@ -1800,9 +2227,9 @@ impl ComponentsObjectBuilder {
             pid: self.pid,
             pindex: self.pindex,
             uuid: self.uuid,
-            slicestackid: crate::core::OptionalResourceId::none(),
-            slicepath: None,
-            meshresolution: None,
+            slicestackid: self.slicestackid,
+            slicepath: self.slicepath,
+            meshresolution: self.meshresolution,
             kind: Some(ObjectKind::Components(components)),
             // components: Some(components),
         })
@@ -2035,6 +2462,9 @@ impl BooleanObjectBuilder {
             pid: OptionalResourceId::none(),
             pindex: OptionalResourceIndex::none(),
             uuid: None,
+            slicestackid: OptionalResourceId::none(),
+            slicepath: None,
+            meshresolution: None,
             is_production_ext_required,
         }
     }
@@ -2055,9 +2485,9 @@ impl BooleanObjectBuilder {
             pid: self.pid,
             pindex: self.pindex,
             uuid: self.uuid,
-            slicestackid: crate::core::OptionalResourceId::none(),
-            slicepath: None,
-            meshresolution: None,
+            slicestackid: self.slicestackid,
+            slicepath: self.slicepath,
+            meshresolution: self.meshresolution,
             kind: Some(ObjectKind::BooleanShape(boolean_shape)),
         })
     }
@@ -2245,21 +2675,6 @@ impl BooleanBuilder {
 /// and references triangles either individually or as ranges.
 ///
 /// Triangle sets are added as a recommended extension (not required).
-///
-/// # Examples
-///
-/// ```rust,ignore
-/// obj.add_triangle_sets(|sets| {
-///     // Add a set referencing specific triangle indices
-///     sets.add_set("TopFace", "top-id", &[0, 1, 2], &[]);
-///
-///     // Add a set using a range of triangles
-///     sets.add_set("SideFaces", "side-id", &[], &[(3, 10)]);
-///
-///     // Mix individual refs and ranges
-///     sets.add_set("Mixed", "mixed-id", &[11, 12], &[(20, 30), (40, 50)]);
-/// });
-/// ```
 pub struct TriangleSetsBuilder {
     sets: Vec<crate::core::triangle_set::TriangleSet>,
 }
@@ -2280,19 +2695,6 @@ impl TriangleSetsBuilder {
     /// - `identifier`: Unique identifier for the set
     /// - `refs`: Slice of individual triangle indices to include
     /// - `ranges`: Slice of triangle index ranges (inclusive start, inclusive end)
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// // Reference triangles 0, 1, and 2 individually
-    /// sets.add_set("Group1", "g1", &[0, 1, 2], &[]);
-    ///
-    /// // Reference triangles 10-20 (inclusive)
-    /// sets.add_set("Group2", "g2", &[], &[(10, 20)]);
-    ///
-    /// // Mix both approaches
-    /// sets.add_set("Group3", "g3", &[5, 6], &[(10, 15), (20, 25)]);
-    /// ```
     pub fn add_set(
         &mut self,
         name: &str,
@@ -2794,6 +3196,486 @@ impl BeamSetBuilder {
     }
 }
 
+/// Builder for a color group resource.
+pub struct ColorGroupBuilder {
+    id: ResourceId,
+    colors: Vec<material::ColorElement>,
+}
+
+impl ColorGroupBuilder {
+    fn new(id: ResourceId) -> Self {
+        Self {
+            id,
+            colors: Vec::new(),
+        }
+    }
+
+    pub fn add_color(&mut self, color: crate::core::Color) -> &mut Self {
+        self.colors.push(material::ColorElement { color });
+        self
+    }
+
+    pub fn add_colors(&mut self, colors: &[crate::core::Color]) -> &mut Self {
+        for color in colors {
+            self.add_color(*color);
+        }
+        self
+    }
+
+    fn build(self) -> ColorGroup {
+        ColorGroup {
+            id: self.id,
+            color: self.colors,
+        }
+    }
+}
+
+/// Builder for a texture2d resource.
+pub struct Texture2DBuilder {
+    id: ResourceId,
+    path: Option<PathResource>,
+    contenttype: Option<material::TextureContentType>,
+    tilestyleu: Option<material::TileStyle>,
+    tilestylev: Option<material::TileStyle>,
+    filter: Option<material::Filter>,
+}
+
+impl Texture2DBuilder {
+    fn new(id: ResourceId) -> Self {
+        Self {
+            id,
+            path: None,
+            contenttype: None,
+            tilestyleu: None,
+            tilestylev: None,
+            filter: None,
+        }
+    }
+
+    pub fn path(&mut self, path: &str) -> &mut Self {
+        match PathResource::try_from(path) {
+            Ok(path) => {
+                self.path = Some(path);
+                self
+            }
+            Err(err) => panic!("{err:?}"),
+        }
+    }
+
+    pub fn content_type(&mut self, content_type: material::TextureContentType) -> &mut Self {
+        self.contenttype = Some(content_type);
+        self
+    }
+
+    pub fn tilestyle_u(&mut self, tilestyle: material::TileStyle) -> &mut Self {
+        self.tilestyleu = Some(tilestyle);
+        self
+    }
+
+    pub fn tilestyle_v(&mut self, tilestyle: material::TileStyle) -> &mut Self {
+        self.tilestylev = Some(tilestyle);
+        self
+    }
+
+    pub fn filter(&mut self, filter: material::Filter) -> &mut Self {
+        self.filter = Some(filter);
+        self
+    }
+
+    fn build(self) -> Result<Texture2D, Texture2DError> {
+        Ok(Texture2D {
+            id: self.id,
+            path: self.path.ok_or(Texture2DError::PathNotSet)?,
+            contenttype: self.contenttype.ok_or(Texture2DError::ContentTypeNotSet)?,
+            tilestyleu: self.tilestyleu,
+            tilestylev: self.tilestylev,
+            filter: self.filter,
+        })
+    }
+}
+
+/// Builder for a texture2d group resource.
+pub struct Texture2DGroupBuilder {
+    id: ResourceId,
+    texid: Option<ResourceId>,
+    tex2coord: Vec<material::Tex2Coord>,
+}
+
+impl Texture2DGroupBuilder {
+    fn new(id: ResourceId) -> Self {
+        Self {
+            id,
+            texid: None,
+            tex2coord: Vec::new(),
+        }
+    }
+
+    pub fn texid(&mut self, texid: ResourceId) -> &mut Self {
+        self.texid = Some(texid);
+        self
+    }
+
+    pub fn add_tex_coord(&mut self, u: f64, v: f64) -> &mut Self {
+        self.tex2coord.push(material::Tex2Coord {
+            u: u.into(),
+            v: v.into(),
+        });
+        self
+    }
+
+    pub fn add_tex_coords(&mut self, coords: &[(f64, f64)]) -> &mut Self {
+        for &(u, v) in coords {
+            self.add_tex_coord(u, v);
+        }
+        self
+    }
+
+    fn build(self) -> Result<Texture2DGroup, Texture2DGroupError> {
+        Ok(Texture2DGroup {
+            id: self.id,
+            texid: self.texid.ok_or(Texture2DGroupError::TexIdNotSet)?,
+            tex2coord: self.tex2coord,
+        })
+    }
+}
+
+/// Builder for composite materials.
+pub struct CompositeMaterialsBuilder {
+    id: ResourceId,
+    matid: Option<ResourceId>,
+    matindices: Vec<ResourceIndex>,
+    composite: Vec<material::Composite>,
+}
+
+impl CompositeMaterialsBuilder {
+    fn new(id: ResourceId) -> Self {
+        Self {
+            id,
+            matid: None,
+            matindices: Vec::new(),
+            composite: Vec::new(),
+        }
+    }
+
+    pub fn matid(&mut self, matid: ResourceId) -> &mut Self {
+        self.matid = Some(matid);
+        self
+    }
+
+    pub fn matindices(&mut self, matindices: &[ResourceIndex]) -> &mut Self {
+        self.matindices = matindices.to_vec();
+        self
+    }
+
+    pub fn add_matindex(&mut self, matindex: ResourceIndex) -> &mut Self {
+        self.matindices.push(matindex);
+        self
+    }
+
+    pub fn add_composite(&mut self, values: &[f64]) -> &mut Self {
+        self.composite.push(material::Composite {
+            values: values.iter().copied().map(Into::into).collect(),
+        });
+        self
+    }
+
+    pub fn add_composites(&mut self, values: &[Vec<f64>]) -> &mut Self {
+        for composite in values {
+            self.add_composite(composite);
+        }
+        self
+    }
+
+    fn build(self) -> Result<CompositeMaterials, CompositeMaterialsError> {
+        if self.matindices.is_empty() {
+            return Err(CompositeMaterialsError::MatIndicesEmpty);
+        }
+        Ok(CompositeMaterials {
+            id: self.id,
+            matid: self.matid.ok_or(CompositeMaterialsError::MatIdNotSet)?,
+            matindices: ResourceIndexCollection::from(self.matindices),
+            composite: self.composite,
+        })
+    }
+}
+
+/// Builder for multi-properties.
+pub struct MultiPropertiesBuilder {
+    id: ResourceId,
+    pids: Vec<ResourceId>,
+    blendmethods: Option<StrResource>,
+    multi: Vec<material::Multi>,
+}
+
+impl MultiPropertiesBuilder {
+    fn new(id: ResourceId) -> Self {
+        Self {
+            id,
+            pids: Vec::new(),
+            blendmethods: None,
+            multi: Vec::new(),
+        }
+    }
+
+    pub fn pids(&mut self, pids: &[ResourceId]) -> &mut Self {
+        self.pids = pids.to_vec();
+        self
+    }
+
+    pub fn add_pid(&mut self, pid: ResourceId) -> &mut Self {
+        self.pids.push(pid);
+        self
+    }
+
+    pub fn blendmethods(&mut self, methods: &[material::BlendMethod]) -> &mut Self {
+        let value = methods
+            .iter()
+            .map(|method| match method {
+                material::BlendMethod::Mix => "mix",
+                material::BlendMethod::Multiply => "multiply",
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+        self.blendmethods = Some(StrResource::new(&value));
+        self
+    }
+
+    pub fn blendmethods_raw(&mut self, methods: &str) -> &mut Self {
+        self.blendmethods = Some(StrResource::new(methods));
+        self
+    }
+
+    pub fn add_multi(&mut self, pindices: &[ResourceIndex]) -> &mut Self {
+        self.multi.push(material::Multi {
+            pindices: ResourceIndexCollection::from(pindices.to_vec()),
+        });
+        self
+    }
+
+    fn build(self) -> Result<MultiProperties, MultiPropertiesError> {
+        if self.pids.is_empty() {
+            return Err(MultiPropertiesError::PidsEmpty);
+        }
+        Ok(MultiProperties {
+            id: self.id,
+            pids: ResourceIdCollection::from(self.pids),
+            blendmethods: self.blendmethods,
+            multi: self.multi,
+        })
+    }
+}
+
+/// Builder for base materials.
+pub struct BaseMaterialsBuilder {
+    id: ResourceId,
+    bases: Vec<Base>,
+}
+
+impl BaseMaterialsBuilder {
+    fn new(id: ResourceId) -> Self {
+        Self {
+            id,
+            bases: Vec::new(),
+        }
+    }
+
+    pub fn add_base(&mut self, name: &str, displaycolor: &str) -> &mut Self {
+        self.bases.push(Base {
+            name: StrResource::new(name),
+            displaycolor: StrResource::new(displaycolor),
+        });
+        self
+    }
+
+    pub fn add_base_color(&mut self, name: &str, displaycolor: crate::core::Color) -> &mut Self {
+        self.bases.push(Base {
+            name: StrResource::new(name),
+            displaycolor: StrResource::new(displaycolor.to_hex_compact()),
+        });
+        self
+    }
+
+    fn build(self) -> BaseMaterials {
+        BaseMaterials {
+            id: self.id,
+            base: self.bases,
+        }
+    }
+}
+
+/// Builder for displacement2d resources.
+pub struct Displacement2DBuilder {
+    id: ResourceId,
+    path: Option<PathResource>,
+    channel: Option<displacement::ChannelName>,
+    tilestyleu: Option<displacement::TileStyle>,
+    tilestylev: Option<displacement::TileStyle>,
+    filter: Option<displacement::Filter>,
+}
+
+impl Displacement2DBuilder {
+    fn new(id: ResourceId) -> Self {
+        Self {
+            id,
+            path: None,
+            channel: None,
+            tilestyleu: None,
+            tilestylev: None,
+            filter: None,
+        }
+    }
+
+    pub fn path(&mut self, path: &str) -> &mut Self {
+        match PathResource::try_from(path) {
+            Ok(path) => {
+                self.path = Some(path);
+                self
+            }
+            Err(err) => panic!("{err:?}"),
+        }
+    }
+
+    pub fn channel(&mut self, channel: displacement::ChannelName) -> &mut Self {
+        self.channel = Some(channel);
+        self
+    }
+
+    pub fn tilestyle_u(&mut self, tilestyle: displacement::TileStyle) -> &mut Self {
+        self.tilestyleu = Some(tilestyle);
+        self
+    }
+
+    pub fn tilestyle_v(&mut self, tilestyle: displacement::TileStyle) -> &mut Self {
+        self.tilestylev = Some(tilestyle);
+        self
+    }
+
+    pub fn filter(&mut self, filter: displacement::Filter) -> &mut Self {
+        self.filter = Some(filter);
+        self
+    }
+
+    fn build(self) -> Result<Displacement2D, Displacement2DError> {
+        Ok(Displacement2D {
+            id: self.id,
+            path: self.path.ok_or(Displacement2DError::PathNotSet)?,
+            channel: self.channel,
+            tilestyleu: self.tilestyleu,
+            tilestylev: self.tilestylev,
+            filter: self.filter,
+        })
+    }
+}
+
+/// Builder for norm vector groups.
+pub struct NormVectorGroupBuilder {
+    id: ResourceId,
+    vectors: Vec<NormVector>,
+}
+
+impl NormVectorGroupBuilder {
+    fn new(id: ResourceId) -> Self {
+        Self {
+            id,
+            vectors: Vec::new(),
+        }
+    }
+
+    pub fn add_norm_vector(&mut self, x: f64, y: f64, z: f64) -> &mut Self {
+        self.vectors.push(NormVector {
+            x: x.into(),
+            y: y.into(),
+            z: z.into(),
+        });
+        self
+    }
+
+    pub fn add_norm_vectors(&mut self, vectors: &[[f64; 3]]) -> &mut Self {
+        for vector in vectors {
+            self.add_norm_vector(vector[0], vector[1], vector[2]);
+        }
+        self
+    }
+
+    fn build(self) -> NormVectorGroup {
+        NormVectorGroup {
+            id: self.id,
+            normvector: self.vectors,
+        }
+    }
+}
+
+/// Builder for displacement 2d groups.
+pub struct Disp2DGroupBuilder {
+    id: ResourceId,
+    dispid: Option<ResourceId>,
+    nid: Option<ResourceId>,
+    height: Option<f64>,
+    offset: Option<f64>,
+    coords: Vec<displacement::Disp2DCoord>,
+}
+
+impl Disp2DGroupBuilder {
+    fn new(id: ResourceId) -> Self {
+        Self {
+            id,
+            dispid: None,
+            nid: None,
+            height: None,
+            offset: None,
+            coords: Vec::new(),
+        }
+    }
+
+    pub fn displacement_map_id(&mut self, dispid: ResourceId) -> &mut Self {
+        self.dispid = Some(dispid);
+        self
+    }
+
+    pub fn norm_vector_group_id(&mut self, nid: ResourceId) -> &mut Self {
+        self.nid = Some(nid);
+        self
+    }
+
+    pub fn height(&mut self, height: f64) -> &mut Self {
+        self.height = Some(height);
+        self
+    }
+
+    pub fn offset(&mut self, offset: f64) -> &mut Self {
+        self.offset = Some(offset);
+        self
+    }
+
+    pub fn add_coord(&mut self, u: f64, v: f64, n: ResourceIndex, f: Option<f64>) -> &mut Self {
+        self.coords.push(displacement::Disp2DCoord {
+            u: u.into(),
+            v: v.into(),
+            n,
+            f: f.map(Into::into),
+        });
+        self
+    }
+
+    pub fn add_coords(&mut self, coords: &[(f64, f64, ResourceIndex, Option<f64>)]) -> &mut Self {
+        for &(u, v, n, f) in coords {
+            self.add_coord(u, v, n, f);
+        }
+        self
+    }
+
+    fn build(self) -> Result<Disp2DGroup, Disp2DGroupError> {
+        Ok(Disp2DGroup {
+            id: self.id,
+            dispid: self.dispid.ok_or(Disp2DGroupError::DispIdNotSet)?,
+            nid: self.nid.ok_or(Disp2DGroupError::NormVectorGroupIdNotSet)?,
+            height: self.height.ok_or(Disp2DGroupError::HeightNotSet)?.into(),
+            offset: self.offset.map(Into::into),
+            disp2dcoord: self.coords,
+        })
+    }
+}
+
 /// Errors that can occur when SliceStack is built.
 #[derive(Debug, Error, Clone, Copy, PartialEq)]
 pub enum SliceStackBuilderError {
@@ -3081,6 +3963,18 @@ impl PolygonBuilder {
         self
     }
 
+    /// Add a segment with property indices and property id.
+    pub fn add_segment_with_properties_and_pid(
+        &mut self,
+        v2: ResourceIndex,
+        p1: OptionalResourceIndex,
+        p2: OptionalResourceIndex,
+        pid: OptionalResourceId,
+    ) -> &mut Self {
+        self.segments.push(Segment { v2, p1, p2, pid });
+        self
+    }
+
     fn build(self) -> Polygon {
         Polygon {
             startv: self.startv.unwrap_or(0),
@@ -3361,6 +4255,54 @@ mod tests {
                 uri: "http://example.com/rec".to_owned()
             }])
         );
+    }
+
+    #[test]
+    fn test_material_and_displacement_extensions_from_resources() {
+        let mut builder = ModelBuilder::new(Unit::Millimeter, true);
+        builder.add_build(None).unwrap();
+
+        builder.add_color_group(|group| {
+            group.add_color(crate::core::Color {
+                r: 255,
+                g: 0,
+                b: 0,
+                a: 255,
+            });
+        });
+
+        builder
+            .add_displacement2d(|disp| {
+                disp.path("/3D/Textures/disp.png");
+            })
+            .unwrap();
+
+        let model = builder.build().unwrap();
+
+        assert_eq!(
+            model.requiredextensions,
+            ThreemfExtensions::new(&[ThreemfNamespace::Displacement, ThreemfNamespace::Material,])
+        );
+    }
+
+    #[test]
+    fn test_add_displacement_mesh_object() {
+        let mut builder = ModelBuilder::new(Unit::Millimeter, true);
+        builder.add_build(None).unwrap();
+
+        let obj_id = builder
+            .add_displacement_mesh_object(|obj| {
+                obj.add_vertices(&[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]);
+                obj.add_triangle(&[0, 1, 2]);
+                Ok(())
+            })
+            .unwrap();
+
+        builder.add_build_item(obj_id).unwrap();
+
+        let model = builder.build().unwrap();
+        let obj = &model.resources.object[0];
+        assert!(obj.get_displacement_mesh().is_some());
     }
 
     #[cfg(not(feature = "uuid"))]

--- a/threemf2/src/core/builder.rs
+++ b/threemf2/src/core/builder.rs
@@ -4230,13 +4230,13 @@ mod tests {
         let mut builder = ModelBuilder::new(Unit::Millimeter, true);
 
         builder.add_required_extension(ThreemfNamespace::Unknown {
-            prefix: "test".to_owned(),
-            uri: "http://example.com/test".to_owned(),
+            prefix: "test".into(),
+            uri: "http://example.com/test".into(),
         });
 
         builder.add_recommended_extension(ThreemfNamespace::Unknown {
-            prefix: "rec".to_owned(),
-            uri: "http://example.com/rec".to_owned(),
+            prefix: "rec".into(),
+            uri: "http://example.com/rec".into(),
         });
         builder.add_build(None).unwrap();
         let model = builder.build().unwrap();
@@ -4244,15 +4244,15 @@ mod tests {
         assert_eq!(
             model.requiredextensions,
             ThreemfExtensions::new(&[ThreemfNamespace::Unknown {
-                prefix: "test".to_owned(),
-                uri: "http://example.com/test".to_owned()
+                prefix: "test".into(),
+                uri: "http://example.com/test".into()
             }])
         );
         assert_eq!(
             model.recommendedextensions,
             ThreemfExtensions::new(&[ThreemfNamespace::Unknown {
-                prefix: "rec".to_owned(),
-                uri: "http://example.com/rec".to_owned()
+                prefix: "rec".into(),
+                uri: "http://example.com/rec".into()
             }])
         );
     }

--- a/threemf2/src/core/query.rs
+++ b/threemf2/src/core/query.rs
@@ -551,6 +551,14 @@ impl<'a> DisplacementMeshObjectView<'a> {
             .map(|t| [t.p1.into(), t.p2.into(), t.p3.into(), t.pid.into()])
     }
 
+    pub fn triangles_displacement_data(&self) -> impl Iterator<Item = [Option<u32>; 4]> {
+        self.mesh
+            .triangles
+            .triangle
+            .iter()
+            .map(|t| [t.d1.into(), t.d2.into(), t.d3.into(), t.did.into()])
+    }
+
     pub fn triangle_set_count(&self) -> usize {
         self.mesh
             .trianglesets

--- a/threemf2/src/core/types.rs
+++ b/threemf2/src/core/types.rs
@@ -18,6 +18,7 @@ use instant_xml::{Error, FromXml, Kind};
 #[cfg(feature = "speed-optimized-read")]
 use serde::{Deserialize, Serialize};
 
+use thiserror::Error;
 #[cfg(feature = "uuid")]
 use uuid::Uuid;
 
@@ -149,23 +150,32 @@ impl<'xml> FromXml<'xml> for StrResource {
 
 /// Path to a resource inside the 3MF package.
 ///
-/// Normalization rules:
 /// - Backslashes are converted to forward slashes.
 /// - Multiple slashes collapse into a single slash.
 /// - A leading slash is enforced.
-/// - Dot segments ("." or "..") are rejected.
+/// - All path should be a path to a file and not a folder
+/// - Dot segments ("." or "..") are not allowed.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PathResource(StrResource);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum PathResourceError {
+    #[error("Empty path is not a valid Path Resource")]
     EmptyPathNotAllowed,
+
+    #[error("Relative path is not a valid Path Resource")]
     DotSegmentNotAllowed,
+
+    #[error("Path Resource is required to be a file extension")]
+    PathMustBeAFileWithExtension,
 }
 
 impl PathResource {
-    pub fn new(value: &str) -> Result<Self, PathResourceError> {
-        match normalize_path_resource(value) {
+    pub fn new(
+        value: impl Into<CompactString>,
+        path_must_have_extension: bool,
+    ) -> Result<Self, PathResourceError> {
+        match normalize_path_resource(value, path_must_have_extension) {
             Ok(normalized) => Ok(Self(StrResource::new(normalized))),
             Err(err) => Err(err),
         }
@@ -173,6 +183,14 @@ impl PathResource {
 
     pub fn as_str(&self) -> &str {
         &self.0.0
+    }
+
+    pub fn as_str_without_leading_slash(&self) -> &str {
+        if self.as_str().starts_with('/') {
+            &self.as_str()[1..]
+        } else {
+            self.as_str()
+        }
     }
 }
 
@@ -186,7 +204,7 @@ impl TryFrom<&str> for PathResource {
     type Error = PathResourceError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        PathResource::new(value)
+        PathResource::new(value, false)
     }
 }
 
@@ -194,7 +212,7 @@ impl TryFrom<String> for PathResource {
     type Error = PathResourceError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        PathResource::new(&value)
+        PathResource::new(&value, false)
     }
 }
 
@@ -272,27 +290,58 @@ impl<'xml> FromXml<'xml> for PathResource {
     const KIND: Kind = Kind::Scalar;
 }
 
-fn normalize_path_resource(input: &str) -> Result<String, PathResourceError> {
-    let replaced = input.replace('\\', "/");
-    let mut parts: Vec<&str> = Vec::new();
+fn normalize_path_resource(
+    input: impl Into<CompactString>,
+    path_must_have_extension: bool,
+) -> Result<CompactString, PathResourceError> {
+    //ToDo: Remove the allocation here
+    let original = input.into();
+    let replaced = original.replace('\\', "/");
+    let mut final_path = CompactString::new("");
 
-    for part in replaced.split('/') {
-        if part.is_empty() {
-            continue;
+    if replaced.split('/').count() == 1 {
+        //this is a file in the current working directory
+        if path_must_have_extension && replaced.rsplit('.').next().is_none() {
+            return Err(PathResourceError::PathMustBeAFileWithExtension);
+        } else {
+            final_path.push_str(&replaced);
         }
-        if part == "." || part == ".." {
-            return Err(PathResourceError::DotSegmentNotAllowed);
+    } else {
+        let mut peekable = replaced.split('/').peekable();
+        let mut visited_first_item = false;
+        while let Some(part) = peekable.next() {
+            let next_available = peekable.peek().is_some();
+            if path_must_have_extension && !next_available {
+                // this is the final part so it should be a file name with extension split with period
+                if part.rsplit('.').next().is_none() {
+                    return Err(PathResourceError::PathMustBeAFileWithExtension);
+                } else {
+                    final_path.push_str(part);
+                    // this is the last item in the list
+                }
+            } else if part.is_empty() {
+                continue;
+            } else if part == "." || part == ".." {
+                return Err(PathResourceError::DotSegmentNotAllowed);
+            } else {
+                if !visited_first_item && next_available {
+                    final_path.push('/');
+                    visited_first_item = true;
+                }
+                final_path.push_str(part);
+                if next_available {
+                    final_path.push('/');
+                }
+                // visited_valid_parts += 1;
+            }
         }
-        parts.push(part);
     }
 
-    if parts.is_empty() {
+    if final_path.is_empty() {
         return Err(PathResourceError::EmptyPathNotAllowed);
     }
 
-    let mut out = String::from("/");
-    out.push_str(&parts.join("/"));
-    Ok(out)
+    Ok(final_path)
 }
 
 /// Optional UUID resource value used by the Production extension.

--- a/threemf2/src/io/builder.rs
+++ b/threemf2/src/io/builder.rs
@@ -1,0 +1,617 @@
+use std::collections::{HashMap, HashSet};
+
+use compact_str::format_compact;
+use thiserror::Error;
+
+use crate::{
+    core::{
+        StrResource,
+        model::Model,
+        types::{PathResource, PathResourceError},
+    },
+    io::{
+        ThreemfPackage,
+        content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
+        relationship::{Relationship, RelationshipType, Relationships},
+        thumbnail_handle::{ImageFormat, ThumbnailHandle},
+    },
+};
+
+const DEFAULT_ROOT_MODEL_PATH: &str = "/3D/3Dmodel.model";
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum PackageBuildError {
+    #[error("Root model is not set")]
+    RootModelNotSet,
+
+    #[error("Duplicate model path: {0}")]
+    DuplicateModelPath(String),
+
+    #[error("Referenced model path not found: {0}")]
+    MissingModel(String),
+
+    #[error("Invalid model path: {0}")]
+    InvalidModelPath(String),
+
+    // #[error("ContentTypes missing required defaults: {0}")]
+    // ContentTypesMissingRequiredDefaults(String),
+    #[error("OPC Part Path is missing an extension: {0}")]
+    MissingOPCPartExtension(String),
+}
+
+/// Builder for assembling 3MF packages with multiple model files.
+pub struct ThreemfPackageBuilder {
+    root_model: Option<Model>,
+    root_model_path: PathResource,
+    sub_models: HashMap<PathResource, Model>,
+    content_types: ContentTypes,
+    relationships_overrides: HashMap<PathResource, Relationships>,
+    thumbnails: HashMap<PathResource, ThumbnailHandle>,
+    unknown_parts: HashMap<PathResource, (String, Vec<u8>)>,
+}
+
+impl Default for ThreemfPackageBuilder {
+    fn default() -> Self {
+        Self {
+            root_model: None,
+            root_model_path: PathResource::new(DEFAULT_ROOT_MODEL_PATH, false).unwrap(),
+            sub_models: HashMap::new(),
+            content_types: ContentTypes { defaults: vec![] },
+            relationships_overrides: HashMap::new(),
+            thumbnails: HashMap::new(),
+            unknown_parts: HashMap::new(),
+        }
+    }
+}
+
+impl ThreemfPackageBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set_root_model(&mut self, model: Model) -> &mut Self {
+        self.root_model = Some(model);
+        self.add_model_content_type();
+        self
+    }
+
+    // pub fn set_root_model_path(&mut self, path: &str) -> Result<&mut Self, PackageBuildError> {
+    //     let normalized = normalize_model_path(path)?;
+    //     self.root_model_path = normalized;
+    //     Ok(self)
+    // }
+
+    pub fn add_model(&mut self, path: &str, model: Model) -> Result<&mut Self, PackageBuildError> {
+        let normalized = normalize_model_path(path)?;
+        if normalized == self.root_model_path || self.sub_models.contains_key(&normalized) {
+            return Err(PackageBuildError::DuplicateModelPath(
+                normalized.to_string(),
+            ));
+        }
+        self.sub_models.insert(normalized, model);
+        self.add_model_content_type();
+        Ok(self)
+    }
+
+    // pub fn set_relationships(&mut self, path: &str, relationships: Relationships) -> &mut Self {
+    //     self.relationships_overrides
+    //         .insert(path.to_owned(), relationships);
+    //     self
+    // }
+
+    pub fn add_thumbnail(
+        &mut self,
+        path: &str,
+        data: Vec<u8>,
+    ) -> Result<&mut Self, PackageBuildError> {
+        let normalized = normalize_model_path(path)?;
+        let ext = path.rsplit('.').next();
+        match ext {
+            Some(ext) => {
+                let format = ImageFormat::from_ext(ext);
+                self.thumbnails.insert(
+                    normalized,
+                    ThumbnailHandle {
+                        data,
+                        format: format.clone(),
+                    },
+                );
+
+                match format {
+                    ImageFormat::Png => {
+                        if !self
+                            .content_types
+                            .defaults
+                            .iter()
+                            .any(|c| c.content_type == DefaultContentTypeEnum::ImagePng)
+                        {
+                            self.content_types.defaults.push(DefaultContentTypes {
+                                extension: ext.into(),
+                                content_type: DefaultContentTypeEnum::ImagePng,
+                            });
+                        }
+                    }
+                    ImageFormat::Jpeg => {
+                        if !self
+                            .content_types
+                            .defaults
+                            .iter()
+                            .any(|c| c.content_type == DefaultContentTypeEnum::ImageJPEG)
+                        {
+                            self.content_types.defaults.push(DefaultContentTypes {
+                                extension: ext.into(),
+                                content_type: DefaultContentTypeEnum::ImageJPEG,
+                            });
+                        }
+                    }
+                    ImageFormat::Unknown(unknown_ext) => {
+                        if !self
+                            .content_types
+                            .defaults
+                            .iter()
+                            .any(|c| c.extension == unknown_ext)
+                        {
+                            self.content_types.defaults.push(DefaultContentTypes {
+                                extension: unknown_ext.clone(),
+                                content_type: DefaultContentTypeEnum::Unknown(StrResource::from(
+                                    format_compact!("Image/{unknown_ext}"),
+                                )),
+                            });
+                        }
+                    }
+                }
+                Ok(self)
+            }
+            None => Err(PackageBuildError::MissingOPCPartExtension(path.to_owned())),
+        }
+    }
+
+    pub fn add_unknown_opc_part(
+        &mut self,
+        path: &str,
+        ns: &str,
+        data: Vec<u8>,
+    ) -> Result<&mut Self, PackageBuildError> {
+        let normalized = normalize_model_path(path)?;
+        self.unknown_parts.insert(normalized, (ns.to_owned(), data));
+        let ext = path.rsplit('.').next();
+        match ext {
+            Some(ext) => {
+                if !self
+                    .content_types
+                    .defaults
+                    .iter()
+                    .any(|c| c.extension == ext.into())
+                {
+                    self.content_types.defaults.push(DefaultContentTypes {
+                        extension: ext.into(),
+                        content_type: DefaultContentTypeEnum::Unknown(StrResource::from(ns)),
+                    });
+                }
+                Ok(self)
+            }
+            None => Err(PackageBuildError::MissingOPCPartExtension(path.to_owned())),
+        }
+    }
+
+    pub fn build(mut self) -> Result<ThreemfPackage, PackageBuildError> {
+        let root = self.root_model.ok_or(PackageBuildError::RootModelNotSet)?;
+        let referenced_paths =
+            collect_referenced_model_paths(&self.root_model_path, &root, &self.sub_models);
+
+        for reference in referenced_paths {
+            if *reference == self.root_model_path {
+                continue;
+            }
+            if !self.sub_models.contains_key(reference) {
+                return Err(PackageBuildError::MissingModel(reference.to_string()));
+            }
+        }
+
+        let relationships = build_relationships(
+            &self.root_model_path,
+            &root,
+            &self.sub_models,
+            &self.relationships_overrides,
+            &self.thumbnails,
+        );
+
+        self.content_types.defaults.push(DefaultContentTypes {
+            extension: "rels".into(),
+            content_type: DefaultContentTypeEnum::Relationship,
+        });
+
+        // validate_content_types(&self.content_types)?;
+
+        let mut stripped_unknown_parts = HashMap::new();
+        for (path, (_, part)) in self.unknown_parts {
+            stripped_unknown_parts.insert(path, part);
+        }
+
+        Ok(ThreemfPackage::new(
+            root,
+            self.sub_models,
+            self.thumbnails,
+            stripped_unknown_parts,
+            relationships,
+            self.content_types,
+        ))
+    }
+
+    fn add_model_content_type(&mut self) {
+        if !self
+            .content_types
+            .defaults
+            .iter()
+            .any(|c| c.content_type == DefaultContentTypeEnum::Model)
+        {
+            self.content_types.defaults.push(DefaultContentTypes {
+                extension: "model".into(),
+                content_type: DefaultContentTypeEnum::Model,
+            });
+        }
+    }
+}
+
+fn normalize_model_path(path: &str) -> Result<PathResource, PackageBuildError> {
+    PathResource::new(path, true).map_err(|_| PackageBuildError::InvalidModelPath(path.to_owned()))
+}
+
+fn collect_referenced_model_paths<'a>(
+    root_model_path: &'a PathResource,
+    root: &'a Model,
+    sub_models: &'a HashMap<PathResource, Model>,
+) -> HashSet<&'a PathResource> {
+    let mut referenced = HashSet::new();
+    referenced.extend(collect_model_references(root));
+    referenced.insert(root_model_path);
+    for model in sub_models.values() {
+        referenced.extend(collect_model_references(model));
+    }
+    referenced
+}
+
+fn collect_model_references(model: &Model) -> HashSet<&PathResource> {
+    let mut referenced = HashSet::new();
+
+    for item in &model.build.item {
+        if let Some(path) = &item.path {
+            referenced.insert(path);
+        }
+    }
+
+    for object in &model.resources.object {
+        if let Some(path) = &object.slicepath {
+            referenced.insert(path);
+        }
+
+        if let Some(components) = object.get_components_object() {
+            collect_component_paths(&components.component, &mut referenced);
+        }
+
+        if let Some(shape) = object.get_boolean_shape_object() {
+            if let Some(path) = &shape.path {
+                referenced.insert(path);
+            }
+            for boolean in &shape.booleans {
+                if let Some(path) = &boolean.path {
+                    referenced.insert(path);
+                }
+            }
+        }
+    }
+
+    for slicestack in &model.resources.slicestack {
+        for sliceref in &slicestack.sliceref {
+            referenced.insert(&sliceref.slicepath);
+        }
+    }
+
+    referenced
+}
+
+fn collect_component_paths<'a>(
+    components: &'a [crate::core::component::Component],
+    referenced: &mut HashSet<&'a PathResource>,
+) {
+    for component in components {
+        if let Some(path) = &component.path {
+            referenced.insert(path);
+        }
+    }
+}
+
+fn build_relationships(
+    root_model_path: &PathResource,
+    root: &Model,
+    sub_models: &HashMap<PathResource, Model>,
+    overrides: &HashMap<PathResource, Relationships>,
+    thumbnails: &HashMap<PathResource, ThumbnailHandle>,
+) -> HashMap<PathResource, Relationships> {
+    let mut relationships = HashMap::new();
+
+    let root_rels_path = PathResource::new("_rels/.rels", true).unwrap();
+    if let Some(overrides) = overrides.get(&root_rels_path) {
+        relationships.insert(root_rels_path, overrides.clone());
+    } else {
+        let mut rels = Vec::new();
+        rels.push(Relationship {
+            id: "rel0".into(),
+            target: root_model_path.to_owned(),
+            relationship_type: RelationshipType::Model,
+        });
+
+        let mut rel_index = 1;
+        for path in thumbnails.keys() {
+            rels.push(Relationship {
+                id: format_compact!("rel{rel_index}").into(),
+                target: path.clone(),
+                relationship_type: RelationshipType::Thumbnail,
+            });
+            rel_index += 1;
+        }
+
+        relationships.insert(
+            root_rels_path,
+            Relationships {
+                relationships: rels,
+            },
+        );
+    }
+
+    let mut model_entries = vec![(root_model_path, root)];
+    for (path, model) in sub_models {
+        model_entries.push((path, model));
+    }
+
+    for (model_path, model) in model_entries {
+        if let Ok(rels_path) = rels_path_for_model(model_path) {
+            if overrides.contains_key(&rels_path) {
+                relationships.insert(rels_path.clone(), overrides[&rels_path].clone());
+                continue;
+            }
+
+            let referenced = collect_model_references(model);
+            if referenced.is_empty() {
+                continue;
+            }
+
+            let mut rels = Vec::new();
+            for (index, target) in referenced.into_iter().enumerate() {
+                if target == model_path {
+                    continue;
+                }
+                rels.push(Relationship {
+                    id: format_compact!("rel{}", index).into(),
+                    target: target.clone(),
+                    relationship_type: RelationshipType::Model,
+                });
+            }
+
+            if rels.is_empty() {
+                continue;
+            }
+
+            relationships.insert(
+                rels_path,
+                Relationships {
+                    relationships: rels,
+                },
+            );
+        } else {
+            panic!("Something went wrong with Model Path")
+        }
+    }
+
+    relationships
+}
+
+fn rels_path_for_model(model_path: &PathResource) -> Result<PathResource, PathResourceError> {
+    if let Some((dir, filename)) = model_path.as_str_without_leading_slash().rsplit_once('/') {
+        let path = PathResource::new(
+            format_compact!("{}/_rels/{}.rels", dir, filename).as_str(),
+            true,
+        )?;
+        Ok(path)
+    } else {
+        let path = PathResource::new(
+            format!("_rels/{}.rels", model_path.as_str_without_leading_slash()).as_str(),
+            true,
+        )?;
+        Ok(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::builder::{ModelBuilder, ObjectType, Unit};
+
+    #[test]
+    fn build_multimodel_package() {
+        let mut root_builder = ModelBuilder::new(Unit::Millimeter, true);
+        root_builder.make_production_extension_required().unwrap();
+        root_builder
+            .add_build(Some(crate::core::UuidResource::from("build-uuid")))
+            .unwrap();
+
+        let obj_id = root_builder
+            .add_mesh_object(|obj| {
+                obj.object_type(ObjectType::Model).uuid("obj-uuid");
+                obj.add_vertex(&[0.0, 0.0, 0.0]);
+                Ok(())
+            })
+            .unwrap();
+        root_builder
+            .add_components_object(|obj| {
+                obj.uuid("components-uuid");
+                obj.add_component_advanced(obj_id, |comp| {
+                    comp.uuid("comp-uuid").path("/3D/sub/sub.model");
+                });
+                Ok(())
+            })
+            .unwrap();
+        root_builder
+            .add_build_item_advanced(obj_id, |item| {
+                item.uuid("item-uuid");
+            })
+            .unwrap();
+
+        let root = root_builder.build().unwrap();
+
+        let mut sub_builder = ModelBuilder::new(Unit::Millimeter, false);
+        sub_builder
+            .add_mesh_object(|obj| {
+                obj.object_type(ObjectType::Model);
+                obj.add_vertex(&[0.0, 0.0, 0.0]);
+                Ok(())
+            })
+            .unwrap();
+        let sub = sub_builder.build().unwrap();
+
+        let mut builder = ThreemfPackageBuilder::new();
+        builder.set_root_model(root);
+        builder.add_model("/3D/sub/sub.model", sub).unwrap();
+        builder
+            .add_thumbnail("Thumbnail/thumbnail.png", vec![222, 169])
+            .unwrap();
+        builder
+            .add_unknown_opc_part("/3D/unknown/unknown.txt", "File/Text", vec![255, 180])
+            .unwrap();
+        let package = builder.build().unwrap();
+
+        assert_eq!(package.sub_models.len(), 1);
+        assert!(
+            package
+                .relationships
+                .contains_key(&PathResource::new("_rels/.rels", true).unwrap())
+        );
+        assert!(
+            package
+                .relationships
+                .contains_key(&PathResource::new("3D/_rels/3Dmodel.model.rels", true).unwrap())
+        );
+        assert!(
+            package
+                .thumbnails
+                .contains_key(&PathResource::new("Thumbnail/thumbnail.png", true).unwrap())
+        );
+        assert!(
+            package
+                .sub_models
+                .contains_key(&PathResource::new("3D/sub/sub.model", true).unwrap())
+        );
+        assert!(
+            package
+                .unknown_parts
+                .contains_key(&PathResource::new("3D/unknown/unknown.txt", true).unwrap())
+        );
+        assert_eq!(package.root.build.item.len(), 1);
+
+        assert_eq!(package.content_types.defaults.len(), 4);
+    }
+
+    #[test]
+    fn missing_referenced_model_errors() {
+        let mut root_builder = ModelBuilder::new(Unit::Millimeter, true);
+        root_builder.make_production_extension_required().unwrap();
+        root_builder
+            .add_build(Some(crate::core::UuidResource::from("build-uuid")))
+            .unwrap();
+
+        let obj_id = root_builder
+            .add_mesh_object(|obj| {
+                obj.object_type(ObjectType::Model).uuid("obj-uuid");
+                obj.add_vertex(&[0.0, 0.0, 0.0]);
+                Ok(())
+            })
+            .unwrap();
+        root_builder
+            .add_components_object(|obj| {
+                obj.uuid("components-uuid");
+                obj.add_component_advanced(obj_id, |comp| {
+                    comp.uuid("comp-uuid").path("/3D/missing.model");
+                });
+                Ok(())
+            })
+            .unwrap();
+        root_builder
+            .add_build_item_advanced(obj_id, |item| {
+                item.uuid("item-uuid");
+            })
+            .unwrap();
+
+        let root = root_builder.build().unwrap();
+        let mut builder = ThreemfPackageBuilder::new();
+        builder.set_root_model(root);
+        let result = builder.build();
+
+        assert!(matches!(
+            result,
+            Err(PackageBuildError::MissingModel(path))
+                if path == "/3D/missing.model"
+        ));
+    }
+
+    #[test]
+    fn rels_path_for_model_is_derived() {
+        assert_eq!(
+            rels_path_for_model(&PathResource::new("/3D/sub.model", true).unwrap())
+                .unwrap()
+                .as_str(),
+            "/3D/_rels/sub.model.rels"
+        );
+        assert_eq!(
+            rels_path_for_model(&PathResource::new("sub.model", true).unwrap())
+                .unwrap()
+                .as_str(),
+            "/_rels/sub.model.rels"
+        );
+    }
+
+    #[test]
+    fn invalid_model_path_rejected() {
+        let mut builder = ThreemfPackageBuilder::new();
+        let mut root_builder = ModelBuilder::new(Unit::Millimeter, false);
+        root_builder
+            .add_mesh_object(|obj| {
+                obj.object_type(ObjectType::Model);
+                obj.add_vertex(&[0.0, 0.0, 0.0]);
+                Ok(())
+            })
+            .unwrap();
+        let model = root_builder.build().unwrap();
+
+        let result = builder.add_model("../bad.model", model);
+        assert!(matches!(
+            result,
+            Err(PackageBuildError::InvalidModelPath(path)) if path == "../bad.model"
+        ));
+    }
+
+    #[test]
+    fn content_types_includes_thumbnail_ext() {
+        let mut builder = ThreemfPackageBuilder::new();
+        let mut root_builder = ModelBuilder::new(Unit::Millimeter, true);
+        root_builder.add_build(None).unwrap();
+        let obj_id = root_builder
+            .add_mesh_object(|obj| {
+                obj.object_type(ObjectType::Model);
+                obj.add_vertex(&[0.0, 0.0, 0.0]);
+                Ok(())
+            })
+            .unwrap();
+        root_builder.add_build_item(obj_id).unwrap();
+        builder.set_root_model(root_builder.build().unwrap());
+
+        builder
+            .add_thumbnail("/3D/Thumbnails/thumb.png", vec![0x1, 0x2])
+            .unwrap();
+
+        let package = builder.build().unwrap();
+        assert!(package.content_types.defaults.iter().any(|entry| {
+            entry.extension == "png".into()
+                && entry.content_type == DefaultContentTypeEnum::ImagePng
+        }));
+    }
+}

--- a/threemf2/src/io/content_types.rs
+++ b/threemf2/src/io/content_types.rs
@@ -10,6 +10,8 @@ use instant_xml::{FromXml, Kind};
 #[cfg(feature = "speed-optimized-read")]
 use serde::Deserialize;
 
+use crate::core::StrResource;
+
 /// Content types for the Open Packaging Conventions (OPC).
 /// Contains a collection of [DefaultContentTypes].
 /// [DefaultContentTypes] contains the [DefaultContentTypeEnum] specifying the content type.
@@ -48,7 +50,7 @@ pub enum DefaultContentTypeEnum {
 
     // Represents a Content Type that is not currently known to this library
     // content namespace is stored in the tuple.
-    Unknown(String),
+    Unknown(StrResource),
 }
 
 const RELATIONSHIP_NS: &str = "application/vnd.openxmlformats-package.relationships+xml";
@@ -116,7 +118,7 @@ impl From<String> for DefaultContentTypeEnum {
             MODEL_NS => Self::Model,
             PNG_NS => Self::ImagePng,
             JPEG_NS => Self::ImageJPEG,
-            value => Self::Unknown(value.to_owned()),
+            value => Self::Unknown(StrResource::from(value)),
         }
     }
 }
@@ -137,7 +139,7 @@ pub struct DefaultContentTypes {
         xml(attribute, rename = "Extension")
     )]
     #[cfg_attr(feature = "speed-optimized-read", serde(rename = "Extension"))]
-    pub extension: String,
+    pub extension: StrResource,
 
     #[cfg_attr(
         any(feature = "write", feature = "memory-optimized-read"),
@@ -169,25 +171,25 @@ mod write_tests {
         let content = ContentTypes {
             defaults: vec![
                 DefaultContentTypes {
-                    extension: "rels".to_owned(),
+                    extension: "rels".into(),
                     content_type: DefaultContentTypeEnum::Relationship,
                 },
                 DefaultContentTypes {
-                    extension: "model".to_owned(),
+                    extension: "model".into(),
                     content_type: DefaultContentTypeEnum::Model,
                 },
                 DefaultContentTypes {
-                    extension: "png".to_owned(),
+                    extension: "png".into(),
                     content_type: DefaultContentTypeEnum::ImagePng,
                 },
                 DefaultContentTypes {
-                    extension: "jpg".to_owned(),
+                    extension: "jpg".into(),
                     content_type: DefaultContentTypeEnum::ImageJPEG,
                 },
                 DefaultContentTypes {
-                    extension: "unknown".to_owned(),
+                    extension: "unknown".into(),
                     content_type: DefaultContentTypeEnum::Unknown(
-                        "//some//unknown//content".to_owned(),
+                        "//some//unknown//content".into(),
                     ),
                 },
             ],
@@ -223,19 +225,19 @@ mod memory_optimized_read_tests {
             ContentTypes {
                 defaults: vec![
                     DefaultContentTypes {
-                        extension: "rels".to_owned(),
+                        extension: "rels".into(),
                         content_type: DefaultContentTypeEnum::Relationship,
                     },
                     DefaultContentTypes {
-                        extension: "model".to_owned(),
+                        extension: "model".into(),
                         content_type: DefaultContentTypeEnum::Model,
                     },
                     DefaultContentTypes {
-                        extension: "png".to_owned(),
+                        extension: "png".into(),
                         content_type: DefaultContentTypeEnum::ImagePng,
                     },
                     DefaultContentTypes {
-                        extension: "jpg".to_owned(),
+                        extension: "jpg".into(),
                         content_type: DefaultContentTypeEnum::ImageJPEG,
                     },
                 ],
@@ -256,17 +258,17 @@ mod memory_optimized_read_tests {
             ContentTypes {
                 defaults: vec![
                     DefaultContentTypes {
-                        extension: "rels".to_owned(),
+                        extension: "rels".into(),
                         content_type: DefaultContentTypeEnum::Relationship,
                     },
                     DefaultContentTypes {
-                        extension: "model".to_owned(),
+                        extension: "model".into(),
                         content_type: DefaultContentTypeEnum::Model,
                     },
                     DefaultContentTypes {
-                        extension: "unknown".to_owned(),
+                        extension: "unknown".into(),
                         content_type: DefaultContentTypeEnum::Unknown(
-                            "some/unknown/content".to_owned()
+                            "some/unknown/content".into(),
                         ),
                     }
                 ]
@@ -280,6 +282,8 @@ mod memory_optimized_read_tests {
 mod speed_optimized_read_tests {
     use pretty_assertions::assert_eq;
     use serde_roxmltree::from_str;
+
+    use crate::core::StrResource;
 
     use super::{
         CONTENT_TYPES_NS, ContentTypes, DefaultContentTypeEnum, DefaultContentTypes, JPEG_NS,
@@ -300,19 +304,19 @@ mod speed_optimized_read_tests {
             ContentTypes {
                 defaults: vec![
                     DefaultContentTypes {
-                        extension: "rels".to_owned(),
+                        extension: "rels".into(),
                         content_type: DefaultContentTypeEnum::Relationship,
                     },
                     DefaultContentTypes {
-                        extension: "model".to_owned(),
+                        extension: "model".into(),
                         content_type: DefaultContentTypeEnum::Model,
                     },
                     DefaultContentTypes {
-                        extension: "png".to_owned(),
+                        extension: "png".into(),
                         content_type: DefaultContentTypeEnum::ImagePng,
                     },
                     DefaultContentTypes {
-                        extension: "jpg".to_owned(),
+                        extension: "jpg".into(),
                         content_type: DefaultContentTypeEnum::ImageJPEG,
                     },
                 ],
@@ -333,18 +337,18 @@ mod speed_optimized_read_tests {
             ContentTypes {
                 defaults: vec![
                     DefaultContentTypes {
-                        extension: "rels".to_owned(),
+                        extension: "rels".into(),
                         content_type: DefaultContentTypeEnum::Relationship,
                     },
                     DefaultContentTypes {
-                        extension: "model".to_owned(),
+                        extension: "model".into(),
                         content_type: DefaultContentTypeEnum::Model,
                     },
                     DefaultContentTypes {
-                        extension: "unknown".to_owned(),
-                        content_type: DefaultContentTypeEnum::Unknown(
-                            "some/unknown/content".to_owned()
-                        ),
+                        extension: "unknown".into(),
+                        content_type: DefaultContentTypeEnum::Unknown(StrResource::from(
+                            "some/unknown/content"
+                        ),),
                     }
                 ]
             }

--- a/threemf2/src/io/error.rs
+++ b/threemf2/src/io/error.rs
@@ -1,6 +1,8 @@
 use thiserror::Error;
 use zip::result::ZipError;
 
+use crate::core::types::PathResourceError;
+
 /// An error that can occur while writing a 3MF file
 #[derive(Debug, Error)]
 pub enum Error {
@@ -27,6 +29,9 @@ pub enum Error {
 
     #[error("Resource not found: {0}")]
     ResourceNotFound(String),
+
+    #[error("Path Respurce error")]
+    PathResourceError(#[from] PathResourceError),
 
     #[cfg(feature = "speed-optimized-read")]
     #[error("Deserialization error from serde-roxmltree")]

--- a/threemf2/src/io/mod.rs
+++ b/threemf2/src/io/mod.rs
@@ -8,6 +8,11 @@ mod utils;
 
 pub mod thumbnail_handle;
 
+#[cfg(feature = "io-write")]
+pub mod builder;
+#[cfg(feature = "io-write")]
+pub use builder::ThreemfPackageBuilder;
+
 pub mod validator;
 mod validator_rules;
 

--- a/threemf2/src/io/query.rs
+++ b/threemf2/src/io/query.rs
@@ -72,7 +72,7 @@ pub fn iter_models<'a>(package: &'a ThreemfPackage) -> impl Iterator<Item = Mode
     })
     .chain(package.sub_models.iter().map(|(path, model)| ModelRef {
         model,
-        path: Some(path),
+        path: Some(path.as_str()),
     }))
 }
 

--- a/threemf2/src/io/relationship.rs
+++ b/threemf2/src/io/relationship.rs
@@ -10,6 +10,8 @@ use instant_xml::{FromXml, Kind};
 #[cfg(feature = "speed-optimized-read")]
 use serde::Deserialize;
 
+use crate::core::{PathResource, StrResource};
+
 const RELATIONSHIP_NS: &str = "http://schemas.openxmlformats.org/package/2006/relationships";
 
 /// Represents a relationship of a single part in the 3mf package along with its [RelationshipType]
@@ -29,7 +31,7 @@ pub struct Relationship {
         xml(attribute, rename = "Id")
     )]
     #[cfg_attr(feature = "speed-optimized-read", serde(rename = "Id"))]
-    pub id: String,
+    pub id: StrResource,
 
     /// Target path of the part in the archive.
     #[cfg_attr(
@@ -37,7 +39,7 @@ pub struct Relationship {
         xml(attribute, rename = "Target")
     )]
     #[cfg_attr(feature = "speed-optimized-read", serde(rename = "Target"))]
-    pub target: String,
+    pub target: PathResource,
 
     /// The actual relationship of the target part
     #[cfg_attr(
@@ -76,7 +78,7 @@ pub enum RelationshipType {
 
     /// Represents an unknown part currently by this library
     /// The namespaces of the relationship type is stored in the tuple.
-    Unknown(String),
+    Unknown(StrResource),
 }
 
 const THUMBNAIL_TYPE_NS: &str =
@@ -127,7 +129,7 @@ impl<'xml> FromXml<'xml> for RelationshipType {
         match value.into_owned().as_ref() {
             THUMBNAIL_TYPE_NS => *into = Some(Self::Thumbnail),
             MODEL_TYPE_NS => *into = Some(Self::Model),
-            value => *into = Some(Self::Unknown(value.to_owned())),
+            value => *into = Some(Self::Unknown(value.into())),
         }
 
         Ok(())
@@ -143,7 +145,7 @@ impl From<String> for RelationshipType {
         match value.as_ref() {
             THUMBNAIL_TYPE_NS => Self::Thumbnail,
             MODEL_TYPE_NS => Self::Model,
-            value => Self::Unknown(value.to_owned()),
+            value => Self::Unknown(value.into()),
         }
     }
 }
@@ -154,6 +156,8 @@ mod write_tests {
     use instant_xml::to_string;
     use pretty_assertions::assert_eq;
 
+    use crate::core::PathResource;
+
     use super::{
         MODEL_TYPE_NS, RELATIONSHIP_NS, Relationship, RelationshipType, Relationships,
         THUMBNAIL_TYPE_NS,
@@ -162,25 +166,25 @@ mod write_tests {
     #[test]
     pub fn toxml_relationships_test() {
         let xml_string = format!(
-            r#"<Relationships xmlns="{}"><Relationship Id="someId" Target="//somePath//Of//Resources" Type="{}" /><Relationship Id="someId1" Target="//somePath//Of//Resources" Type="{}" /><Relationship Id="someId2" Target="//somePath//Of//Unknown" Type="unknown" /></Relationships>"#,
+            r#"<Relationships xmlns="{}"><Relationship Id="someId" Target="/somePath/Of/Resources" Type="{}" /><Relationship Id="someId1" Target="/somePath/Of/Resources" Type="{}" /><Relationship Id="someId2" Target="/somePath/Of/Unknown" Type="unknown" /></Relationships>"#,
             RELATIONSHIP_NS, MODEL_TYPE_NS, THUMBNAIL_TYPE_NS
         );
         let relationships = Relationships {
             relationships: vec![
                 Relationship {
-                    id: "someId".to_owned(),
-                    target: "//somePath//Of//Resources".to_owned(),
+                    id: "someId".into(),
+                    target: PathResource::new("/somePath/Of/Resources", true).unwrap(),
                     relationship_type: RelationshipType::Model,
                 },
                 Relationship {
-                    id: "someId1".to_owned(),
-                    target: "//somePath//Of//Resources".to_owned(),
+                    id: "someId1".into(),
+                    target: PathResource::new("/somePath/Of/Resources", true).unwrap(),
                     relationship_type: RelationshipType::Thumbnail,
                 },
                 Relationship {
-                    id: "someId2".to_owned(),
-                    target: "//somePath//Of//Unknown".to_owned(),
-                    relationship_type: RelationshipType::Unknown("unknown".to_owned()),
+                    id: "someId2".into(),
+                    target: PathResource::new("//somePath//Of/Unknown", false).unwrap(),
+                    relationship_type: RelationshipType::Unknown("unknown".into()),
                 },
             ],
         };
@@ -196,6 +200,8 @@ mod memory_optimized_read_tests {
     use instant_xml::from_str;
     use pretty_assertions::assert_eq;
 
+    use crate::core::PathResource;
+
     use super::{
         MODEL_TYPE_NS, RELATIONSHIP_NS, Relationship, RelationshipType, Relationships,
         THUMBNAIL_TYPE_NS,
@@ -214,19 +220,19 @@ mod memory_optimized_read_tests {
             Relationships {
                 relationships: vec![
                     Relationship {
-                        id: "someId".to_owned(),
-                        target: "//somePath//Of//Resources".to_owned(),
+                        id: "someId".into(),
+                        target: PathResource::new("/somePath/Of/Resources", true).unwrap(),
                         relationship_type: RelationshipType::Model,
                     },
                     Relationship {
-                        id: "someId1".to_owned(),
-                        target: "//somePath//Of//Resources".to_owned(),
+                        id: "someId1".into(),
+                        target: PathResource::new("/somePath/Of/Resources", true).unwrap(),
                         relationship_type: RelationshipType::Thumbnail,
                     },
                     Relationship {
-                        id: "someId2".to_owned(),
-                        target: "//somePath//Of//Unknown".to_owned(),
-                        relationship_type: RelationshipType::Unknown("unknown".to_owned()),
+                        id: "someId2".into(),
+                        target: PathResource::new("//somePath//Of/Unknown", false).unwrap(),
+                        relationship_type: RelationshipType::Unknown("unknown".into()),
                     },
                 ],
             }
@@ -240,6 +246,8 @@ mod speed_optimized_read_tests {
     use pretty_assertions::assert_eq;
     use serde_roxmltree::from_str;
 
+    use crate::core::PathResource;
+
     use super::{
         MODEL_TYPE_NS, RELATIONSHIP_NS, Relationship, RelationshipType, Relationships,
         THUMBNAIL_TYPE_NS,
@@ -258,19 +266,19 @@ mod speed_optimized_read_tests {
             Relationships {
                 relationships: vec![
                     Relationship {
-                        id: "someId".to_owned(),
-                        target: "//somePath//Of//Resources".to_owned(),
+                        id: "someId".into(),
+                        target: PathResource::new("/somePath/Of/Resources", true).unwrap(),
                         relationship_type: RelationshipType::Model,
                     },
                     Relationship {
-                        id: "someId1".to_owned(),
-                        target: "//somePath//Of//Resources".to_owned(),
+                        id: "someId1".into(),
+                        target: PathResource::new("/somePath/Of/Resources", true).unwrap(),
                         relationship_type: RelationshipType::Thumbnail,
                     },
                     Relationship {
-                        id: "someId2".to_owned(),
-                        target: "//somePath//Of//Unknown".to_owned(),
-                        relationship_type: RelationshipType::Unknown("unknown".to_owned()),
+                        id: "someId2".into(),
+                        target: PathResource::new("//somePath//Of/Unknown", false).unwrap(),
+                        relationship_type: RelationshipType::Unknown("unknown".into()),
                     },
                 ],
             }

--- a/threemf2/src/io/threemf_package.rs
+++ b/threemf2/src/io/threemf_package.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "io-write")]
+use compact_str::CompactString;
 use zip::ZipWriter;
 use zip::write::SimpleFileOptions;
 
@@ -5,11 +7,11 @@ use zip::write::SimpleFileOptions;
 use instant_xml::ToXml;
 
 use crate::{
-    core::model::Model,
+    core::{PathResource, model::Model},
     io::{
-        content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
+        content_types::{ContentTypes, DefaultContentTypeEnum},
         error::Error,
-        relationship::{Relationship, RelationshipType, Relationships},
+        relationship::{RelationshipType, Relationships},
         thumbnail_handle::ThumbnailHandle,
         utils,
     },
@@ -37,22 +39,22 @@ pub struct ThreemfPackage {
     /// The sub models contained in the file. Usually this is to represent the [Object](crate::core::object::Object)
     /// that are to be referenced in the [root](ThreemfPackage::root) model part.
     /// The key is the path of the model in the archive package.
-    pub sub_models: HashMap<String, Model>,
+    pub sub_models: HashMap<PathResource, Model>,
 
     /// The thumbnails contained in the file.
     /// The key is the path of the thumbnail in the archive package.
     /// The thumbnail paths defined in the [Model](crate::core::model::Model) object should match the keys in this dictionary.
-    pub thumbnails: HashMap<String, ThumbnailHandle>,
+    pub thumbnails: HashMap<PathResource, ThumbnailHandle>,
 
     /// Bytes of additional data found through Unknown relationship
     /// The key is the path of the thumbnail in the archive package.
-    pub unknown_parts: HashMap<String, Vec<u8>>,
+    pub unknown_parts: HashMap<PathResource, Vec<u8>>,
 
     /// The relationships between the different parts in the 3mf package.
     /// The key is the path of the relationship file in the archive package.
     /// Always expected to have at least 1 relationship file,
     /// the root relationship file placed within "_rels" folder at the root of the package
-    pub relationships: HashMap<String, Relationships>,
+    pub relationships: HashMap<PathResource, Relationships>,
 
     /// A summary of all Default Content Types that exists in the current 3mf package.
     /// The reader/writer will still read and write data not currently known to library as
@@ -65,10 +67,10 @@ pub struct ThreemfPackage {
 impl ThreemfPackage {
     pub fn new(
         root: Model,
-        sub_models: HashMap<String, Model>,
-        thumbnails: HashMap<String, ThumbnailHandle>,
-        unknown_parts: HashMap<String, Vec<u8>>,
-        relationships: HashMap<String, Relationships>,
+        sub_models: HashMap<PathResource, Model>,
+        thumbnails: HashMap<PathResource, ThumbnailHandle>,
+        unknown_parts: HashMap<PathResource, Vec<u8>>,
+        relationships: HashMap<PathResource, Relationships>,
         content_types: ContentTypes,
     ) -> Self {
         Self {
@@ -98,13 +100,18 @@ impl ThreemfPackage {
         )?;
 
         for (path, relationships) in &self.relationships {
-            Self::archive_write_xml_with_header(&mut zip, path, &relationships, None)?;
+            Self::archive_write_xml_with_header(
+                &mut zip,
+                path.as_str_without_leading_slash(),
+                &relationships,
+                None,
+            )?;
 
             for relationship in &relationships.relationships {
-                let filename = utils::try_strip_leading_slash(&relationship.target);
+                let filename = relationship.target.as_str_without_leading_slash();
                 match relationship.relationship_type {
                     RelationshipType::Model => {
-                        let model = if *path == *"_rels/.rels" {
+                        let model = if path.as_str() == "/_rels/.rels" {
                             &self.root
                         } else if let Some(model) = self.sub_models.get(&relationship.target) {
                             model
@@ -188,7 +195,7 @@ impl ThreemfPackage {
 
             // Parse all attributes (simple approach: split by spaces)
             let mut all_attrs = Vec::new();
-            let mut current_attr = String::new();
+            let mut current_attr = CompactString::new("");
             let mut in_quotes = false;
 
             for ch in tag_content[6..].chars() {
@@ -199,7 +206,7 @@ impl ThreemfPackage {
                 } else if ch == ' ' && !in_quotes {
                     if !current_attr.is_empty() {
                         all_attrs.push(current_attr);
-                        current_attr = String::new();
+                        current_attr = CompactString::new("");
                     }
                 } else if ch == '>' {
                     if !current_attr.is_empty() {
@@ -283,7 +290,7 @@ impl ThreemfPackage {
 
         let (mut zip, content_types, _, root_rels_filename) =
             zip_utils::setup_archive_and_content_types(reader, deserializer)?;
-
+        //println!("{:?}", zip.file_names().collect::<Vec<_>>());
         let rels_ext = {
             let rels_content = content_types
                 .defaults
@@ -296,7 +303,7 @@ impl ThreemfPackage {
             }
         };
 
-        let mut relationships = HashMap::<String, Relationships>::new();
+        let mut relationships = HashMap::<PathResource, Relationships>::new();
 
         let root_rels: Relationships = zip_utils::relationships_from_zip_by_name(
             &mut zip,
@@ -321,12 +328,15 @@ impl ThreemfPackage {
         relationships.insert(root_rels_filename.clone(), root_rels.clone());
 
         if process_sub_models {
-            let rel_files =
-                zip_utils::discover_relationship_files(&mut zip, rels_ext, &root_rels_filename)?;
+            let rel_files = zip_utils::discover_relationship_files(
+                &mut zip,
+                rels_ext,
+                root_rels_filename.as_str(),
+            )?;
             for rel_file_path in rel_files {
                 let rels = zip_utils::relationships_from_zip_by_name(
                     &mut zip,
-                    &rel_file_path[1..],
+                    &rel_file_path,
                     &deserializer,
                 )?;
                 relationships.insert(rel_file_path, rels);
@@ -346,10 +356,13 @@ impl ThreemfPackage {
         model_path: Option<&str>,
     ) -> Option<Vec<ThreemfNamespace>> {
         match model_path {
-            Some(sub_model_path) => self
-                .sub_models
-                .get(sub_model_path)
-                .map(|sub_model| sub_model.used_namespaces()),
+            Some(sub_model_path) => match PathResource::new(sub_model_path, true) {
+                Ok(path) => self
+                    .sub_models
+                    .get(&path)
+                    .map(|sub_model| sub_model.used_namespaces()),
+                Err(_) => None,
+            },
             None => Some(self.root.used_namespaces()),
         }
     }
@@ -375,14 +388,14 @@ mod processor {
     use zip::ZipArchive;
 
     use crate::{
-        core::model::Model,
+        core::{PathResource, model::Model},
         io::{
+            Error::ThumbnailError,
             ThreemfPackage,
             content_types::ContentTypes,
             error::Error,
             relationship::{RelationshipType, Relationships},
             thumbnail_handle::{ImageFormat, ThumbnailHandle},
-            utils,
             zip_utils::{self, XmlDeserializer},
         },
     };
@@ -394,10 +407,10 @@ mod processor {
     /// Temporary processor for building ThreemfPackage
     pub(crate) struct ThreemfPackageProcessor {
         root: Option<Model>,
-        sub_models: HashMap<String, Model>,
-        thumbnails: HashMap<String, ThumbnailHandle>,
-        unknown_parts: HashMap<String, Vec<u8>>,
-        relationships: HashMap<String, Relationships>,
+        sub_models: HashMap<PathResource, Model>,
+        thumbnails: HashMap<PathResource, ThumbnailHandle>,
+        unknown_parts: HashMap<PathResource, Vec<u8>>,
+        relationships: HashMap<PathResource, Relationships>,
         content_types: ContentTypes,
         // namespaces_map: HashMap<String, Vec<XmlNamespace>>,
     }
@@ -405,7 +418,7 @@ mod processor {
     impl ThreemfPackageProcessor {
         pub(crate) fn new(
             content_types: ContentTypes,
-            relationships: HashMap<String, Relationships>,
+            relationships: HashMap<PathResource, Relationships>,
         ) -> Self {
             Self {
                 root: None,
@@ -433,12 +446,12 @@ mod processor {
             &mut self,
             zip: &mut ZipArchive<R>,
             deserializer: &XmlDeserializer,
-            root_model_path: &str,
+            root_model_path: &PathResource,
         ) -> Result<(), Error> {
             for rels in self.relationships.values() {
                 for rel in &rels.relationships {
-                    let name = utils::try_strip_leading_slash(&rel.target);
-                    let zip_file = zip.by_name(name);
+                    let path = rel.target.as_str_without_leading_slash();
+                    let zip_file = zip.by_name(path);
 
                     match zip_file {
                         Ok(mut file) => {
@@ -462,7 +475,9 @@ mod processor {
                                         {
                                             ImageFormat::from_ext(ext)
                                         } else {
-                                            ImageFormat::Unknown
+                                            return Err(ThumbnailError(format!(
+                                                "Referenced thumbnail path: {path:?} is not a valid archive path to thumbnail data"
+                                            )));
                                         }
                                     };
 
@@ -470,18 +485,17 @@ mod processor {
                                         data: bytes,
                                         format,
                                     };
-                                    self.thumbnails
-                                        .insert(rel.target.to_string(), thumbnail_rep);
+                                    self.thumbnails.insert(rel.target.clone(), thumbnail_rep);
                                 }
                                 RelationshipType::Model => {
-                                    let is_root = rel.target == root_model_path;
+                                    let is_root = &rel.target == root_model_path;
                                     let model_string =
                                         zip_utils::read_zipfile_to_string(&mut file)?;
                                     let model = deserializer.deserialize_model(&model_string)?;
                                     if is_root {
                                         self.root = Some(model);
                                     } else {
-                                        self.sub_models.insert(rel.target.to_string(), model);
+                                        self.sub_models.insert(rel.target.clone(), model);
                                     }
                                 }
                                 RelationshipType::Unknown(_) => {
@@ -489,7 +503,7 @@ mod processor {
                                     let mut bytes = Vec::with_capacity(size);
                                     file.read_to_end(&mut bytes)?;
 
-                                    self.unknown_parts.insert(rel.target.to_string(), bytes);
+                                    self.unknown_parts.insert(rel.target.clone(), bytes);
                                 }
                             }
                         }
@@ -499,41 +513,6 @@ mod processor {
             }
             Ok(())
         }
-    }
-}
-
-impl From<Model> for ThreemfPackage {
-    fn from(value: Model) -> Self {
-        let mut rels = HashMap::new();
-        rels.insert(
-            "_rels/.rels".to_owned(),
-            Relationships {
-                relationships: vec![Relationship {
-                    id: "rel0".to_owned(),
-                    target: "3D/3dmodel.model".to_owned(),
-                    relationship_type: RelationshipType::Model,
-                }],
-            },
-        );
-        Self::new(
-            value,
-            HashMap::new(),
-            HashMap::new(),
-            HashMap::new(),
-            rels,
-            ContentTypes {
-                defaults: vec![
-                    DefaultContentTypes {
-                        extension: "model".to_owned(),
-                        content_type: DefaultContentTypeEnum::Model,
-                    },
-                    DefaultContentTypes {
-                        extension: "rels".to_owned(),
-                        content_type: DefaultContentTypeEnum::Relationship,
-                    },
-                ],
-            },
-        )
     }
 }
 
@@ -547,6 +526,7 @@ mod tests {
             model::{self, Model},
             object::{Object, ObjectType},
             resources::Resources,
+            types::PathResource,
         },
         io::{content_types::*, relationship::*},
     };
@@ -573,19 +553,23 @@ mod tests {
                 assert_eq!(threemf.thumbnails.len(), 1);
                 assert_eq!(threemf.relationships.len(), 2);
 
-                assert!(threemf.sub_models.contains_key("/3D/midway.model"));
+                assert!(
+                    threemf
+                        .sub_models
+                        .contains_key(&PathResource::new("/3D/midway.model", true).unwrap())
+                );
 
-                assert!(threemf.relationships.contains_key("_rels/.rels"));
                 assert!(
                     threemf
                         .relationships
-                        .contains_key("/3D/_rels/3dmodel.model.rels")
+                        .contains_key(&PathResource::new("_rels/.rels", true).unwrap())
                 );
-                assert!(
-                    threemf
-                        .thumbnails
-                        .contains_key("/Thumbnails/P_XPX_0702_02.png")
-                )
+                assert!(threemf.relationships.contains_key(
+                    &PathResource::new("/3D/_rels/3dmodel.model.rels", true).unwrap()
+                ));
+                assert!(threemf.thumbnails.contains_key(
+                    &PathResource::new("/Thumbnails/P_XPX_0702_02.png", true).unwrap()
+                ))
             }
             Err(err) => panic!("{:?}", err),
         }
@@ -607,19 +591,23 @@ mod tests {
                 assert_eq!(threemf.thumbnails.len(), 1);
                 assert_eq!(threemf.relationships.len(), 2);
 
-                assert!(threemf.sub_models.contains_key("/3D/midway.model"));
+                assert!(
+                    threemf
+                        .sub_models
+                        .contains_key(&PathResource::new("/3D/midway.model", true).unwrap())
+                );
 
-                assert!(threemf.relationships.contains_key("_rels/.rels"));
                 assert!(
                     threemf
                         .relationships
-                        .contains_key("/3D/_rels/3dmodel.model.rels")
+                        .contains_key(&PathResource::new("_rels/.rels", true).unwrap())
                 );
-                assert!(
-                    threemf
-                        .thumbnails
-                        .contains_key("/Thumbnails/P_XPX_0702_02.png")
-                )
+                assert!(threemf.relationships.contains_key(
+                    &PathResource::new("/3D/_rels/3dmodel.model.rels", true).unwrap()
+                ));
+                assert!(threemf.thumbnails.contains_key(
+                    &PathResource::new("/Thumbnails/P_XPX_0702_02.png", true).unwrap()
+                ))
             }
             Err(err) => panic!("{:?}", err),
         }
@@ -630,7 +618,8 @@ mod tests {
     pub fn write_root_model_test() {
         let bytes = {
             use crate::core::{
-                OptionalResourceId, OptionalResourceIndex, UuidResource, model::ThreemfExtensions,
+                OptionalResourceId, OptionalResourceIndex, PathResource, UuidResource,
+                model::ThreemfExtensions,
             };
 
             let bytes = Vec::<u8>::new();
@@ -676,11 +665,11 @@ mod tests {
                 HashMap::new(),
                 HashMap::new(),
                 HashMap::from([(
-                    "_rels/.rels".to_owned(),
+                    PathResource::new("_rels/.rels", true).unwrap(),
                     Relationships {
                         relationships: vec![Relationship {
-                            id: "rel0".to_owned(),
-                            target: "3D/3Dmodel.model".to_owned(),
+                            id: "rel0".into(),
+                            target: PathResource::new("3D/3Dmodel.model", true).unwrap(),
                             relationship_type: RelationshipType::Model,
                         }],
                     },
@@ -688,32 +677,33 @@ mod tests {
                 ContentTypes {
                     defaults: vec![
                         DefaultContentTypes {
-                            extension: "rels".to_owned(),
+                            extension: "rels".into(),
                             content_type: DefaultContentTypeEnum::Relationship,
                         },
                         DefaultContentTypes {
-                            extension: "model".to_owned(),
+                            extension: "model".into(),
                             content_type: DefaultContentTypeEnum::Model,
                         },
                     ],
                 },
             );
+            println!("{threemf:?}");
             threemf.write(&mut writer).unwrap();
             writer
         };
 
         // usually breaks due to additional namespace declaration that arent filtered out
-        assert_eq!(bytes.into_inner().len(), 944);
+        assert_eq!(bytes.into_inner().len(), 945);
     }
 
     #[cfg(all(feature = "io-memory-optimized-read", feature = "io-write"))]
     #[test]
     pub fn io_unknown_content_test() {
-        use crate::core::model::ThreemfExtensions;
+        use crate::core::{StrResource, model::ThreemfExtensions};
 
         let test_file_bytes = include_bytes!("../../tests/data/test.txt");
         let mut writer = Cursor::new(Vec::<u8>::new());
-        let unknown_target = "/Metadata/test.txt";
+        let unknown_target = PathResource::new("/Metadata/test.txt", true).unwrap();
 
         let package = ThreemfPackage::new(
             Model {
@@ -741,22 +731,20 @@ mod tests {
             },
             HashMap::new(),
             HashMap::new(),
-            HashMap::from([(unknown_target.to_owned(), test_file_bytes.into())]),
+            HashMap::from([(unknown_target.clone(), test_file_bytes.into())]),
             HashMap::from([(
-                "_rels/.rels".to_owned(),
+                PathResource::new("_rels/.rels", true).unwrap(),
                 Relationships {
                     relationships: vec![
                         Relationship {
-                            id: "rel0".to_owned(),
-                            target: "3D/3Dmodel.model".to_owned(),
+                            id: "rel0".into(),
+                            target: PathResource::new("3D/3Dmodel.model", true).unwrap(),
                             relationship_type: RelationshipType::Model,
                         },
                         Relationship {
-                            id: "rel1".to_owned(),
-                            target: unknown_target.to_owned(),
-                            relationship_type: RelationshipType::Unknown(
-                                "Metadata/text".to_owned(),
-                            ),
+                            id: "rel1".into(),
+                            target: unknown_target.clone(),
+                            relationship_type: RelationshipType::Unknown("Metadata/text".into()),
                         },
                     ],
                 },
@@ -765,14 +753,16 @@ mod tests {
                 defaults: vec![
                     DefaultContentTypes {
                         content_type: DefaultContentTypeEnum::Relationship,
-                        extension: "rels".to_owned(),
+                        extension: "rels".into(),
                     },
                     DefaultContentTypes {
-                        content_type: DefaultContentTypeEnum::Unknown("Metadata/text".to_owned()),
-                        extension: "txt".to_owned(),
+                        content_type: DefaultContentTypeEnum::Unknown(StrResource::from(
+                            "Metadata/text",
+                        )),
+                        extension: "txt".into(),
                     },
                     DefaultContentTypes {
-                        extension: "model".to_owned(),
+                        extension: "model".into(),
                         content_type: DefaultContentTypeEnum::Model,
                     },
                 ],
@@ -787,8 +777,8 @@ mod tests {
 
         match read_result {
             Ok(package) => {
-                assert!(package.unknown_parts.contains_key(unknown_target));
-                let read_unknown_bytes = package.unknown_parts.get(unknown_target).unwrap();
+                assert!(package.unknown_parts.contains_key(&unknown_target));
+                let read_unknown_bytes = package.unknown_parts.get(&unknown_target).unwrap();
                 assert_eq!(read_unknown_bytes, test_file_bytes);
             }
             Err(_) => panic!("io unknown content test failed"),
@@ -810,7 +800,7 @@ mod tests {
         };
 
         let mut writer = Cursor::new(Vec::<u8>::new());
-        let thumbnail_target = "/Thumbnails/test_thumbnail.png";
+        let thumbnail_target = PathResource::new("/Thumbnails/test_thumbnail.png", true).unwrap();
 
         let package = ThreemfPackage::new(
             Model {
@@ -840,17 +830,17 @@ mod tests {
             HashMap::from([(thumbnail_target.to_owned(), thumbnail_rep)]),
             HashMap::new(),
             HashMap::from([(
-                "_rels/.rels".to_owned(),
+                PathResource::new("_rels/.rels", true).unwrap(),
                 Relationships {
                     relationships: vec![
                         Relationship {
-                            id: "rel0".to_owned(),
-                            target: "3D/3Dmodel.model".to_owned(),
+                            id: "rel0".into(),
+                            target: PathResource::new("3D/3Dmodel.model", true).unwrap(),
                             relationship_type: RelationshipType::Model,
                         },
                         Relationship {
-                            id: "rel0x".to_owned(),
-                            target: thumbnail_target.to_owned(),
+                            id: "rel0x".into(),
+                            target: thumbnail_target.clone(),
                             relationship_type: RelationshipType::Thumbnail,
                         },
                     ],
@@ -860,14 +850,14 @@ mod tests {
                 defaults: vec![
                     DefaultContentTypes {
                         content_type: DefaultContentTypeEnum::Relationship,
-                        extension: "rels".to_owned(),
+                        extension: "rels".into(),
                     },
                     DefaultContentTypes {
                         content_type: DefaultContentTypeEnum::ImagePng,
-                        extension: "png".to_owned(),
+                        extension: "png".into(),
                     },
                     DefaultContentTypes {
-                        extension: "model".to_owned(),
+                        extension: "model".into(),
                         content_type: DefaultContentTypeEnum::Model,
                     },
                 ],
@@ -884,8 +874,8 @@ mod tests {
             Ok(package) => {
                 use crate::io::thumbnail_handle::ImageFormat;
 
-                assert!(package.thumbnails.contains_key(thumbnail_target));
-                let thumbnail_rep = package.thumbnails.get(thumbnail_target).unwrap();
+                assert!(package.thumbnails.contains_key(&thumbnail_target));
+                let thumbnail_rep = package.thumbnails.get(&thumbnail_target).unwrap();
                 assert_eq!(thumbnail_rep.data.len(), 8571);
                 assert_eq!(thumbnail_rep.format, ImageFormat::Png);
             }

--- a/threemf2/src/io/threemf_package_lazy_reader.rs
+++ b/threemf2/src/io/threemf_package_lazy_reader.rs
@@ -5,7 +5,9 @@ use std::io::{Read, Seek};
 use once_cell::unsync::OnceCell;
 use zip::ZipArchive;
 
+use crate::core::PathResource;
 use crate::core::model::Model;
+use crate::io::Error::ThumbnailError;
 use crate::io::thumbnail_handle::{ImageFormat, ThumbnailHandle};
 use crate::io::utils;
 use crate::io::{
@@ -39,16 +41,16 @@ pub struct ThreemfPackageLazyReader<R: Read + Seek> {
 
     // always eagerly loaded
     content_types: ContentTypes,
-    relationships: HashMap<String, Relationships>,
-    root_model_path: String,
+    relationships: HashMap<PathResource, Relationships>,
+    root_model_path: PathResource,
 
     // always cached on first access
     root_model: OnceCell<Model>,
 
     // cached based on cachepolicy
-    sub_models: RefCell<HashMap<String, Model>>,
-    thumbnails: RefCell<HashMap<String, ThumbnailHandle>>,
-    unknown_parts: RefCell<HashMap<String, Vec<u8>>>,
+    sub_models: RefCell<HashMap<PathResource, Model>>,
+    thumbnails: RefCell<HashMap<PathResource, ThumbnailHandle>>,
+    unknown_parts: RefCell<HashMap<PathResource, Vec<u8>>>,
 }
 
 impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
@@ -72,7 +74,7 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
             }
         };
 
-        let mut relationships = HashMap::<String, Relationships>::new();
+        let mut relationships = HashMap::new();
         let root_rels: Relationships = zip_utils::relationships_from_zip_by_name(
             &mut zip,
             &root_rels_filename,
@@ -88,14 +90,14 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
 
         relationships.insert(root_rels_filename.to_owned(), root_rels);
 
-        let rel_files =
-            zip_utils::discover_relationship_files(&mut zip, rels_ext, &root_rels_filename)?;
+        let rel_files = zip_utils::discover_relationship_files(
+            &mut zip,
+            rels_ext,
+            root_rels_filename.as_str(),
+        )?;
         for rel_file_path in rel_files {
-            let rels = zip_utils::relationships_from_zip_by_name(
-                &mut zip,
-                &rel_file_path[1..],
-                &deserializer,
-            )?;
+            let rels =
+                zip_utils::relationships_from_zip_by_name(&mut zip, &rel_file_path, &deserializer)?;
             relationships.insert(rel_file_path, rels);
         }
 
@@ -117,34 +119,34 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
         &self.content_types
     }
 
-    pub fn relationships(&self) -> &HashMap<String, Relationships> {
+    pub fn relationships(&self) -> &HashMap<PathResource, Relationships> {
         &self.relationships
     }
 
-    pub fn root_model_path(&self) -> &str {
+    pub fn root_model_path(&self) -> &PathResource {
         &self.root_model_path
     }
 
-    pub fn model_paths(&self) -> impl Iterator<Item = &str> {
+    pub fn model_paths(&self) -> impl Iterator<Item = &PathResource> {
         self.relationships
             .values()
             .flat_map(|r| &r.relationships)
             .filter_map(|rel| {
                 if matches!(rel.relationship_type, RelationshipType::Model) {
-                    Some(rel.target.as_str())
+                    Some(&rel.target)
                 } else {
                     None
                 }
             })
     }
 
-    pub fn thumbnail_paths(&self) -> impl Iterator<Item = &str> {
+    pub fn thumbnail_paths(&self) -> impl Iterator<Item = &PathResource> {
         self.relationships
             .values()
             .flat_map(|r| &r.relationships)
             .filter_map(|rel| {
                 if matches!(rel.relationship_type, RelationshipType::Thumbnail) {
-                    Some(rel.target.as_str())
+                    Some(&rel.target)
                 } else {
                     None
                 }
@@ -169,11 +171,11 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
             .get_or_try_init(|| self.load_model_from_archive(&self.root_model_path))
     }
 
-    pub fn with_model<F, T>(&self, path: &str, f: F) -> Result<T, Error>
+    pub fn with_model<F, T>(&self, path: &PathResource, f: F) -> Result<T, Error>
     where
         F: FnOnce(&Model) -> T,
     {
-        if path == self.root_model_path {
+        if path == &self.root_model_path {
             let model = self.root_model()?;
             return Ok(f(model));
         }
@@ -183,11 +185,11 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
             .values()
             .flat_map(|r| &r.relationships)
             .any(|rel| {
-                rel.target == path && matches!(rel.relationship_type, RelationshipType::Model)
+                &rel.target == path && matches!(rel.relationship_type, RelationshipType::Model)
             });
 
         if !is_model {
-            return Err(Error::ResourceNotFound(path.to_owned()));
+            return Err(Error::ResourceNotFound(path.to_string()));
         }
 
         match self.cache_policy {
@@ -201,7 +203,7 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
                     Ok(f(model))
                 } else {
                     let model = self.load_model_from_archive(path)?;
-                    self.sub_models.borrow_mut().insert(path.to_string(), model);
+                    self.sub_models.borrow_mut().insert(path.clone(), model);
                     let cache = self.sub_models.borrow();
                     let model = cache.get(path).unwrap();
                     Ok(f(model))
@@ -216,7 +218,7 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
                 } else {
                     // Load and cache
                     let model = self.load_model_from_archive(path)?;
-                    self.sub_models.borrow_mut().insert(path.to_string(), model);
+                    self.sub_models.borrow_mut().insert(path.clone(), model);
                     let cache = self.sub_models.borrow();
                     let model = cache.get(path).unwrap();
                     Ok(f(model))
@@ -225,7 +227,7 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
         }
     }
 
-    pub fn with_thumbnail<F, T>(&self, path: &str, f: F) -> Result<T, Error>
+    pub fn with_thumbnail<F, T>(&self, path: &PathResource, f: F) -> Result<T, Error>
     where
         F: FnOnce(&ThumbnailHandle) -> T,
     {
@@ -235,11 +237,11 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
             .values()
             .flat_map(|r| &r.relationships)
             .any(|rel| {
-                rel.target == path && matches!(rel.relationship_type, RelationshipType::Thumbnail)
+                &rel.target == path && matches!(rel.relationship_type, RelationshipType::Thumbnail)
             });
 
         if !is_thumbnail {
-            return Err(Error::ResourceNotFound(path.to_owned()));
+            return Err(Error::ResourceNotFound(path.to_string()));
         }
 
         if self.thumbnails.borrow().contains_key(path) {
@@ -248,7 +250,7 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
             Ok(f(image))
         } else {
             let image = self.load_thumbnail_from_archive(path)?;
-            self.thumbnails.borrow_mut().insert(path.to_string(), image);
+            self.thumbnails.borrow_mut().insert(path.clone(), image);
             let cache = self.thumbnails.borrow();
             let image = cache.get(path).unwrap();
             Ok(f(image))
@@ -258,7 +260,7 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
     /// Get an unknown part by path (lazy loaded, cached based on policy)
     ///
     /// Returns `None` if no unknown part exists at the given path.
-    pub fn with_unknown_part<F, T>(&self, path: &str, f: F) -> Result<T, Error>
+    pub fn with_unknown_part<F, T>(&self, path: &PathResource, f: F) -> Result<T, Error>
     where
         F: FnOnce(&[u8]) -> T,
     {
@@ -268,11 +270,11 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
             .values()
             .flat_map(|r| &r.relationships)
             .any(|rel| {
-                rel.target == path && matches!(rel.relationship_type, RelationshipType::Unknown(_))
+                &rel.target == path && matches!(rel.relationship_type, RelationshipType::Unknown(_))
             });
 
         if !is_unknown {
-            return Err(Error::ResourceNotFound(path.to_owned()));
+            return Err(Error::ResourceNotFound(path.to_string()));
         }
 
         // Check cache (works for both policies since we need to return a reference)
@@ -283,9 +285,7 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
         } else {
             // Load and cache
             let bytes = self.load_unknown_part_from_archive(path)?;
-            self.unknown_parts
-                .borrow_mut()
-                .insert(path.to_string(), bytes);
+            self.unknown_parts.borrow_mut().insert(path.clone(), bytes);
             let cache = self.unknown_parts.borrow();
             let bytes = cache.get(path).unwrap();
             Ok(f(bytes))
@@ -295,7 +295,7 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
     /// Access raw XML content of a model by path (pull-based, reads from ZIP each time)
     ///
     /// Returns an error if no model exists at the given path.
-    pub fn with_model_xml<F, T>(&self, path: &str, f: F) -> Result<T, Error>
+    pub fn with_model_xml<F, T>(&self, path: &PathResource, f: F) -> Result<T, Error>
     where
         F: FnOnce(&str) -> T,
     {
@@ -305,7 +305,7 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
             .values()
             .flat_map(|r| &r.relationships)
             .any(|rel| {
-                rel.target == path && matches!(rel.relationship_type, RelationshipType::Model)
+                &rel.target == path && matches!(rel.relationship_type, RelationshipType::Model)
             });
 
         if !is_model {
@@ -314,7 +314,7 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
 
         // Read XML directly from ZIP archive
         let mut archive = self.archive.borrow_mut();
-        let mut file = archive.by_name(utils::try_strip_leading_slash(path))?;
+        let mut file = archive.by_name(path.as_str_without_leading_slash())?;
         let mut xml_string = String::new();
         file.read_to_string(&mut xml_string)?;
 
@@ -324,7 +324,7 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
     /// Access raw XML content of relationships by path (pull-based, reads from ZIP each time)
     ///
     /// Returns an error if no relationships file exists at the given path.
-    pub fn with_relationships_xml<F, T>(&self, path: &str, f: F) -> Result<T, Error>
+    pub fn with_relationships_xml<F, T>(&self, path: &PathResource, f: F) -> Result<T, Error>
     where
         F: FnOnce(&str) -> T,
     {
@@ -338,7 +338,7 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
 
         // Read relationships XML directly from ZIP
         let mut archive = self.archive.borrow_mut();
-        let mut file = archive.by_name(utils::try_strip_leading_slash(path))?;
+        let mut file = archive.by_name(path.as_str_without_leading_slash())?;
         let mut xml_string = String::new();
         file.read_to_string(&mut xml_string)?;
 
@@ -359,16 +359,16 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
         Ok(f(&xml_string))
     }
 
-    fn load_model_from_archive(&self, path: &str) -> Result<Model, Error> {
+    fn load_model_from_archive(&self, path: &PathResource) -> Result<Model, Error> {
         let mut archive = self.archive.borrow_mut();
-        let mut file = archive.by_name(utils::try_strip_leading_slash(path))?;
+        let mut file = archive.by_name(path.as_str_without_leading_slash())?;
         let model_string = zip_utils::read_zipfile_to_string(&mut file)?;
         self.deserializer.deserialize_model(&model_string)
     }
 
-    fn load_thumbnail_from_archive(&self, path: &str) -> Result<ThumbnailHandle, Error> {
+    fn load_thumbnail_from_archive(&self, path: &PathResource) -> Result<ThumbnailHandle, Error> {
         let mut archive = self.archive.borrow_mut();
-        let mut file = archive.by_name(utils::try_strip_leading_slash(path))?;
+        let mut file = archive.by_name(path.as_str_without_leading_slash())?;
         let mut bytes: Vec<u8> = vec![];
         file.read_to_end(&mut bytes)?;
 
@@ -379,7 +379,9 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
             {
                 ImageFormat::from_ext(ext)
             } else {
-                ImageFormat::Unknown
+                return Err(ThumbnailError(format!(
+                    "Referenced thumbnail path: {path} is not a valid archive path to thumbnail data"
+                )));
             }
         };
 
@@ -390,9 +392,9 @@ impl<R: Read + Seek> ThreemfPackageLazyReader<R> {
         Ok(thumbnail_rep)
     }
 
-    fn load_unknown_part_from_archive(&self, path: &str) -> Result<Vec<u8>, Error> {
+    fn load_unknown_part_from_archive(&self, path: &PathResource) -> Result<Vec<u8>, Error> {
         let mut archive = self.archive.borrow_mut();
-        let mut file = archive.by_name(utils::try_strip_leading_slash(path))?;
+        let mut file = archive.by_name(path.as_str_without_leading_slash())?;
         let mut bytes: Vec<u8> = vec![];
         file.read_to_end(&mut bytes)?;
         Ok(bytes)
@@ -453,7 +455,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(package.relationships().len(), 1);
-        assert!(package.root_model_path().contains("3dmodel.model"));
+        assert!(package.root_model_path().as_str().contains("3dmodel.model"));
 
         let paths: Vec<_> = package.model_paths().collect();
         assert!(!paths.is_empty());
@@ -485,12 +487,12 @@ mod tests {
         assert!(!root_model.resources.object.is_empty());
         assert_eq!(root_model.used_namespaces().len(), 2);
 
-        let sub_model_path = "/3D/midway.model";
-        let exists = package.with_model(sub_model_path, |_| true);
+        let sub_model_path = PathResource::new("/3D/midway.model", true).unwrap();
+        let exists = package.with_model(&sub_model_path, |_| true);
         assert!(exists.is_ok());
 
-        let sub_model_path = "/SomeThing/ThatDoesNotExist.model";
-        let exists = package.with_model(sub_model_path, |_| true);
+        let sub_model_path = PathResource::new("/SomeThing/ThatDoesNotExist.model", true).unwrap();
+        let exists = package.with_model(&sub_model_path, |_| true);
         assert!(exists.is_err());
     }
 
@@ -552,24 +554,30 @@ mod tests {
 
         // Test model XML extraction
         package
-            .with_model_xml("/3D/3dmodel.model", |xml| {
-                assert!(xml.contains("<model"));
-                assert!(xml.contains("</model>"));
-                assert!(xml.contains("xmlns"));
-            })
+            .with_model_xml(
+                &PathResource::new("/3D/3dmodel.model", true).unwrap(),
+                |xml| {
+                    assert!(xml.contains("<model"));
+                    assert!(xml.contains("</model>"));
+                    assert!(xml.contains("xmlns"));
+                },
+            )
             .unwrap();
 
         // Test sub-model XML extraction
         package
-            .with_model_xml("/3D/midway.model", |xml| {
-                assert!(xml.contains("<model"));
-                assert!(xml.contains("</model>"));
-            })
+            .with_model_xml(
+                &PathResource::new("/3D/midway.model", true).unwrap(),
+                |xml| {
+                    assert!(xml.contains("<model"));
+                    assert!(xml.contains("</model>"));
+                },
+            )
             .unwrap();
 
         // Test relationships XML extraction
         package
-            .with_relationships_xml("_rels/.rels", |xml| {
+            .with_relationships_xml(&PathResource::new("_rels/.rels", true).unwrap(), |xml| {
                 assert!(xml.contains("<Relationships"));
                 assert!(xml.contains("<Relationship"));
             })
@@ -577,9 +585,12 @@ mod tests {
 
         // Test sub-model relationships XML extraction
         package
-            .with_relationships_xml("/3D/_rels/3dmodel.model.rels", |xml| {
-                assert!(xml.contains("<Relationships"));
-            })
+            .with_relationships_xml(
+                &PathResource::new("/3D/_rels/3dmodel.model.rels", true).unwrap(),
+                |xml| {
+                    assert!(xml.contains("<Relationships"));
+                },
+            )
             .unwrap();
 
         // Test content types XML extraction
@@ -591,10 +602,16 @@ mod tests {
             .unwrap();
 
         // Test invalid paths return errors
-        let invalid_result = package.with_model_xml("/invalid/path.model", |_| ());
+        let invalid_result = package.with_model_xml(
+            &PathResource::new("/invalid/path.model", true).unwrap(),
+            |_| (),
+        );
         assert!(matches!(invalid_result, Err(Error::ResourceNotFound(_))));
 
-        let invalid_rels = package.with_relationships_xml("/invalid/rels.xml", |_| ());
+        let invalid_rels = package.with_relationships_xml(
+            &PathResource::new("/invalid/rels.xml", true).unwrap(),
+            |_| (),
+        );
         assert!(matches!(invalid_rels, Err(Error::ResourceNotFound(_))));
     }
 }

--- a/threemf2/src/io/thumbnail_handle.rs
+++ b/threemf2/src/io/thumbnail_handle.rs
@@ -1,8 +1,10 @@
+use crate::core::StrResource;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ImageFormat {
     Png,
     Jpeg,
-    Unknown,
+    Unknown(StrResource),
 }
 
 impl ImageFormat {
@@ -10,7 +12,15 @@ impl ImageFormat {
         match ext.to_lowercase().as_ref() {
             "png" => Self::Png,
             "jpg" | "jpeg" => Self::Jpeg,
-            _ => Self::Unknown,
+            _ => Self::Unknown(ext.into()),
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            ImageFormat::Png => "png",
+            ImageFormat::Jpeg => "jpeg",
+            ImageFormat::Unknown(ext) => ext,
         }
     }
 }
@@ -35,6 +45,6 @@ mod tests {
         assert_eq!(png, ImageFormat::Png);
         assert_eq!(jpg, ImageFormat::Jpeg);
         assert_eq!(jpeg, ImageFormat::Jpeg);
-        assert_eq!(unknown, ImageFormat::Unknown);
+        assert_eq!(unknown, ImageFormat::Unknown("tiff".into()));
     }
 }

--- a/threemf2/src/io/utils.rs
+++ b/threemf2/src/io/utils.rs
@@ -1,12 +1,5 @@
 use crate::io::XmlNamespace;
 
-pub(crate) fn try_strip_leading_slash(target: &str) -> &str {
-    match target.strip_prefix('/') {
-        Some(stripped) => stripped,
-        None => target,
-    }
-}
-
 /// Extracts xmlns attribute declarations from an XML element attribute definitions
 pub fn parse_xmlns_attributes(tag_content: &str) -> Vec<XmlNamespace> {
     let mut attributes = Vec::new();

--- a/threemf2/src/io/zip_utils.rs
+++ b/threemf2/src/io/zip_utils.rs
@@ -1,7 +1,8 @@
+use compact_str::format_compact;
 use zip::ZipArchive;
 
 use crate::{
-    core::model::ThreemfExtensions,
+    core::{PathResource, StrResource, model::ThreemfExtensions},
     io::{
         content_types::{ContentTypes, DefaultContentTypeEnum},
         error::Error,
@@ -92,10 +93,7 @@ fn speed_optimized_read(xml_string: &str) -> Model {
     for ns in model.recommendedextensions.get() {
         match ns {
             ThreemfNamespace::Unknown { prefix, uri } => {
-                if let Some(ns) = namespaces
-                    .clone()
-                    .find(|ns| ns.name() == Some(prefix.as_str()))
-                {
+                if let Some(ns) = namespaces.clone().find(|ns| ns.name() == Some(prefix)) {
                     let threemf_ns = ThreemfNamespace::try_from_uri(ns.uri(), ns.name()).unwrap();
                     new_recommended_extensions.insert(threemf_ns);
                 } else {
@@ -115,10 +113,7 @@ fn speed_optimized_read(xml_string: &str) -> Model {
     for ns in model.requiredextensions.get() {
         match ns {
             ThreemfNamespace::Unknown { prefix, uri } => {
-                if let Some(ns) = namespaces
-                    .clone()
-                    .find(|ns| ns.name() == Some(prefix.as_str()))
-                {
+                if let Some(ns) = namespaces.clone().find(|ns| ns.name() == Some(prefix)) {
                     let threemf_ns = ThreemfNamespace::try_from_uri(ns.uri(), ns.name()).unwrap();
                     new_required_extensions.insert(threemf_ns);
                 } else {
@@ -155,15 +150,21 @@ pub(crate) fn read_zipfile_to_string<R: Read>(
 pub(crate) fn setup_archive_and_content_types<R: Read + Seek>(
     reader: R,
     deserializer: XmlDeserializer,
-) -> Result<(ZipArchive<R>, ContentTypes, String, String), Error> {
+) -> Result<(ZipArchive<R>, ContentTypes, String, PathResource), Error> {
     let mut zip = ZipArchive::new(reader)?;
 
     let (content_types, content_types_string) = parse_content_types(&mut zip, deserializer)?;
     let rels_ext = determine_relationships_extension(&content_types);
 
-    let root_rels_filename = "_rels/.{extension}".replace("{extension}", &rels_ext);
+    //let root_rels_filename = "_rels/.{extension}".replace("{extension}", &rels_ext);
+    let root_rels_filename = format_compact!("_rels/.{}", rels_ext);
 
-    Ok((zip, content_types, content_types_string, root_rels_filename))
+    match PathResource::new(root_rels_filename, true) {
+        Ok(path) => Ok((zip, content_types, content_types_string, path)),
+        Err(err) => Err(Error::PathResourceError(err)),
+    }
+
+    //Ok((zip, content_types, content_types_string, root_rels_filename))
 }
 
 fn parse_content_types<R: Read + Seek>(
@@ -181,13 +182,13 @@ fn parse_content_types<R: Read + Seek>(
     }
 }
 
-fn determine_relationships_extension(content_types: &ContentTypes) -> String {
+fn determine_relationships_extension(content_types: &ContentTypes) -> StrResource {
     content_types
         .defaults
         .iter()
         .find(|t| t.content_type == DefaultContentTypeEnum::Relationship)
         .map(|rels| rels.extension.clone())
-        .unwrap_or_else(|| "rels".to_string())
+        .unwrap_or_else(|| "rels".into())
 }
 
 /// Find all relationship files in the archive (excluding the root relationships file)
@@ -195,7 +196,7 @@ pub(crate) fn discover_relationship_files<R: Read + Seek>(
     zip: &mut ZipArchive<R>,
     rels_ext: &str,
     root_rels_filename: &str,
-) -> Result<Vec<String>, Error> {
+) -> Result<Vec<PathResource>, Error> {
     let mut rel_files = Vec::new();
 
     for i in 0..zip.len() {
@@ -211,9 +212,12 @@ pub(crate) fn discover_relationship_files<R: Read + Seek>(
                 .map(|c| c.as_os_str().to_string_lossy())
                 .collect::<Vec<_>>()
                 .join("/");
-            let final_path = format!("/{zip_name}");
+            let final_path = format_compact!("/{zip_name}");
 
-            rel_files.push(final_path);
+            match PathResource::new(final_path, true) {
+                Ok(path) => rel_files.push(path),
+                Err(err) => return Err(Error::PathResourceError(err)),
+            }
         }
     }
 
@@ -230,10 +234,10 @@ pub(crate) fn relationships_from_zipfile<R: Read>(
 
 pub(crate) fn relationships_from_zip_by_name<R: Read + Seek>(
     zip: &mut ZipArchive<R>,
-    zip_filename: &str,
+    zip_filename: &PathResource,
     deserializer: &XmlDeserializer,
 ) -> Result<Relationships, Error> {
-    let rels_file = zip.by_name(zip_filename);
+    let rels_file = zip.by_name(zip_filename.as_str_without_leading_slash());
     match rels_file {
         Ok(file) => relationships_from_zipfile(file, deserializer),
         Err(err) => Err(Error::Zip(err)),

--- a/threemf2/src/threemf_namespaces.rs
+++ b/threemf2/src/threemf_namespaces.rs
@@ -1,3 +1,5 @@
+use crate::core::StrResource;
+
 ////////////////////////////////////////////////////////////////////////////////////
 ///  Namespaces & Prefixes related to the Core specification and its extensions
 pub const CORE_NS: &str = "http://schemas.microsoft.com/3dmanufacturing/core/2015/02";
@@ -72,7 +74,10 @@ pub enum ThreemfNamespace {
     Displacement,
 
     /// Unknown namespace
-    Unknown { prefix: String, uri: String },
+    Unknown {
+        prefix: StrResource,
+        uri: StrResource,
+    },
 }
 
 impl ThreemfNamespace {
@@ -122,8 +127,8 @@ impl ThreemfNamespace {
             MATERIAL_NS => Some(Self::Material),
             DISPLACEMENT_NS => Some(Self::Displacement),
             _ => assigned_prefix.map(|prefix| Self::Unknown {
-                prefix: prefix.to_owned(),
-                uri: uri.to_owned(),
+                prefix: prefix.into(),
+                uri: uri.into(),
             }),
         }
     }
@@ -141,12 +146,12 @@ impl ThreemfNamespace {
             DISPLACEMENT_PREFIX => Some(Self::Displacement),
             _ => match specified_uri {
                 Some(uri) => Some(Self::Unknown {
-                    prefix: prefix.to_owned(),
-                    uri: uri.to_owned(),
+                    prefix: prefix.into(),
+                    uri: uri.into(),
                 }),
                 None => Some(Self::Unknown {
-                    prefix: prefix.to_owned(),
-                    uri: "".to_owned(),
+                    prefix: prefix.into(),
+                    uri: "".into(),
                 }),
             },
         }

--- a/threemf2/tests/displacement_io.rs
+++ b/threemf2/tests/displacement_io.rs
@@ -71,7 +71,10 @@ mod tests {
     #[cfg(all(feature = "io-lazy-read", feature = "io-memory-optimized-read"))]
     #[test]
     fn read_displacement_package_lazy_memory_optimized() {
-        use threemf2::io::{CachePolicy, ThreemfPackageLazyReader};
+        use threemf2::{
+            core::PathResource,
+            io::{CachePolicy, ThreemfPackageLazyReader},
+        };
 
         let path =
             PathBuf::from("./tests/data/mgx-core-prod-beamlattice-material-displacement-mesh.3mf");
@@ -84,15 +87,18 @@ mod tests {
         .unwrap();
 
         package
-            .with_model("/3D/3dmodel.model", |model| {
-                assert_eq!(
-                    core_query::get_displacement_mesh_objects_from_model(model).count(),
-                    1
-                );
-                assert!(core_query::get_displacement2d_by_id(3, model).is_some());
-                assert!(core_query::get_normvectorgroup_by_id(4, model).is_some());
-                assert!(core_query::get_disp2dgroup_by_id(5, model).is_some());
-            })
+            .with_model(
+                &PathResource::new("/3D/3dmodel.model", true).unwrap(),
+                |model| {
+                    assert_eq!(
+                        core_query::get_displacement_mesh_objects_from_model(model).count(),
+                        1
+                    );
+                    assert!(core_query::get_displacement2d_by_id(3, model).is_some());
+                    assert!(core_query::get_normvectorgroup_by_id(4, model).is_some());
+                    assert!(core_query::get_disp2dgroup_by_id(5, model).is_some());
+                },
+            )
             .unwrap();
     }
 }

--- a/threemf2/tests/production_io.rs
+++ b/threemf2/tests/production_io.rs
@@ -154,7 +154,7 @@ mod tests {
                     package
                         .with_model(model_path, |model| {
                             //check if some part with some id exists in a specific sub-model
-                            if model_path == "/3D/Objects/Object.model"
+                            if model_path.as_str() == "/3D/Objects/Object.model"
                                 && model.resources.object.iter().any(|o| o.id == 1)
                             {
                                 found_object_by_id = true;
@@ -247,7 +247,7 @@ mod tests {
                     package
                         .with_model(model_path, |model| {
                             //check if some part with some id exists in a specific sub-model
-                            if model_path == "/3D/Objects/Object.model"
+                            if model_path.as_str() == "/3D/Objects/Object.model"
                                 && model.resources.object.iter().any(|o| o.id == 1)
                             {
                                 found_object_by_id = true;

--- a/threemf2/tests/roundtrip.rs
+++ b/threemf2/tests/roundtrip.rs
@@ -19,14 +19,10 @@ mod tests {
             resources::Resources,
             types::OptionalResourceIndex,
         },
-        io::{
-            ThreemfPackage,
-            content_types::{ContentTypes, DefaultContentTypeEnum, DefaultContentTypes},
-            relationship::{Relationship, RelationshipType, Relationships},
-        },
+        io::{ThreemfPackage, ThreemfPackageBuilder},
     };
 
-    use std::{collections::HashMap, io::Cursor};
+    use std::io::Cursor;
 
     #[test]
     fn roundtrip_threemfpackage_test() {
@@ -57,78 +53,54 @@ mod tests {
             beamlattice: None,
         };
 
-        let write_package = ThreemfPackage::new(
-            Model {
-                unit: Some(Unit::Millimeter),
-                requiredextensions: ThreemfExtensions::default(),
-                recommendedextensions: ThreemfExtensions::default(),
-                metadata: vec![],
-                resources: Resources {
-                    object: vec![Object {
-                        id: 1,
-                        objecttype: Some(ObjectType::Model),
-                        thumbnail: None,
-                        partnumber: None,
-                        name: Some("Mesh".into()),
-                        pid: OptionalResourceId::none(),
-                        pindex: OptionalResourceIndex::none(),
-                        uuid: None,
-                        kind: Some(ObjectKind::Mesh(mesh.clone())),
-                        slicestackid: OptionalResourceId::none(),
-                        slicepath: None,
-                        meshresolution: None,
-                    }],
-                    basematerials: vec![],
-                    slicestack: vec![],
-                    colorgroup: Vec::new(),
-                    texture2dgroup: Vec::new(),
-                    compositematerials: Vec::new(),
-                    multiproperties: Vec::new(),
-                    texture2d: Vec::new(),
-                    displacement2d: Vec::new(),
-                    normvectorgroup: Vec::new(),
-                    disp2dgroup: Vec::new(),
-                },
-                build: Build {
+        let model = Model {
+            unit: Some(Unit::Millimeter),
+            requiredextensions: ThreemfExtensions::default(),
+            recommendedextensions: ThreemfExtensions::default(),
+            metadata: vec![],
+            resources: Resources {
+                object: vec![Object {
+                    id: 1,
+                    objecttype: Some(ObjectType::Model),
+                    thumbnail: None,
+                    partnumber: None,
+                    name: Some("Mesh".into()),
+                    pid: OptionalResourceId::none(),
+                    pindex: OptionalResourceIndex::none(),
                     uuid: None,
-                    item: vec![Item {
-                        objectid: 1,
-                        transform: None,
-                        partnumber: None,
-                        path: None,
-                        uuid: None,
-                    }],
-                },
+                    kind: Some(ObjectKind::Mesh(mesh.clone())),
+                    slicestackid: OptionalResourceId::none(),
+                    slicepath: None,
+                    meshresolution: None,
+                }],
+                basematerials: vec![],
+                slicestack: vec![],
+                colorgroup: Vec::new(),
+                texture2dgroup: Vec::new(),
+                compositematerials: Vec::new(),
+                multiproperties: Vec::new(),
+                texture2d: Vec::new(),
+                displacement2d: Vec::new(),
+                normvectorgroup: Vec::new(),
+                disp2dgroup: Vec::new(),
             },
-            HashMap::new(),
-            HashMap::new(),
-            HashMap::new(),
-            HashMap::from([(
-                "_rels/.rels".to_owned(),
-                Relationships {
-                    relationships: vec![Relationship {
-                        id: "rel0".to_owned(),
-                        target: "3D/3Dmodel.model".to_owned(),
-                        relationship_type: RelationshipType::Model,
-                    }],
-                },
-            )]),
-            ContentTypes {
-                defaults: vec![
-                    DefaultContentTypes {
-                        extension: "rels".to_owned(),
-                        content_type: DefaultContentTypeEnum::Relationship,
-                    },
-                    DefaultContentTypes {
-                        extension: "model".to_owned(),
-                        content_type: DefaultContentTypeEnum::Model,
-                    },
-                ],
+            build: Build {
+                uuid: None,
+                item: vec![Item {
+                    objectid: 1,
+                    transform: None,
+                    partnumber: None,
+                    path: None,
+                    uuid: None,
+                }],
             },
-        );
+        };
+
+        let mut builder = ThreemfPackageBuilder::new();
+        builder.set_root_model(model);
+        let write_package = builder.build().expect("Error building package");
 
         let mut buf = Cursor::new(Vec::new());
-
         write_package
             .write(&mut buf)
             .expect("Error writing package");
@@ -167,7 +139,12 @@ mod tests {
 
             // Verify basic structure
             assert_eq!(lazy_package.relationships().len(), 1);
-            assert!(lazy_package.root_model_path().contains("3Dmodel.model"));
+            assert!(
+                lazy_package
+                    .root_model_path()
+                    .as_str()
+                    .contains("3Dmodel.model")
+            );
 
             // Verify root model content
             let root_model = lazy_package.root_model().unwrap();


### PR DESCRIPTION
- new ThreemfPackageBuilder is added
- Migrated all relevant examples to use `ThreemfPackageBuilder` instead of `ThreemfPackage` directly
- Migrated ThreemfPackage to use PathResource to manage the internal paths of the diferrent OPC parts
- ImageFormat for ThumbnailHandle now carries the possible extension for identification method
- PathResource now has more stricter validation for paths of file with extensions when expected optionally. 
- Some fields of the OPC serializable types are now using PathResource or StrResource types to hopefully benefit from SSO. 
- Extended the core::query and core::builder modules with Additional functionalities
- Migrated some leftover fields that can use StrResource in the core module